### PR TITLE
Adds missing tests & implementation for Menu role attribute removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Fixed**
 
 - Updates NPM dependencies (#25)
+- Corrects issues with `Menu.destroy()` (#26)
 
 ## 0.2.0
 

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -194,8 +194,10 @@ describe('Destroying the Menu removes attributes', () => {
     expect(domElements.sublistOneSecondItem.getAttribute('aria-posinset')).toBeNull();
     expect(domElements.sublistTwoLastItem.getAttribute('aria-posinset')).toBeNull();
 
-    expect(domElements.sublistTwoSecondItem.getAttribute('role')).toBeNull();
+    expect(domElements.list.getAttribute('role')).toBeNull();
     expect(domElements.sublistTwoSecondItem.parentElement.getAttribute('role')).toBeNull();
+    expect(domElements.sublistOne.getAttribute('role')).toBeNull();
+    expect(domElements.sublistTwoSecondItem.getAttribute('role')).toBeNull();
 
     expect(onDestroy).toHaveBeenCalled();
   });

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -335,6 +335,9 @@ export default class Menu extends AriaComponent {
     // Remove the list's role attritbute.
     this.list.removeAttribute('role');
 
+    // Remove event listener.
+    this.list.removeEventListener('keydown', this.handleListKeydown);
+
     this.menuItems.forEach((link) => {
       // Remove list item role.
       link.parentElement.removeAttribute('role');
@@ -344,9 +347,6 @@ export default class Menu extends AriaComponent {
       link.removeAttribute('aria-describedby');
       link.removeAttribute('aria-setsize');
       link.removeAttribute('aria-posinset');
-
-      // Remove event listeners.
-      link.removeEventListener('keydown', this.handleListKeydown);
 
       // Destroy nested Menus.
       const siblingList = this.constructor.nextElementIsUl(link);

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -332,6 +332,9 @@ export default class Menu extends AriaComponent {
     // Remove the reference to the class instance.
     this.deleteSelfReferences();
 
+    // Remove the list's role attritbute.
+    this.list.removeAttribute('role');
+
     this.menuItems.forEach((link) => {
       // Remove list item role.
       link.parentElement.removeAttribute('role');


### PR DESCRIPTION
This corrects a couple issues with the Menu `destroy()` method.