### PR TITLE
Doc and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Changed**
 
 - Uses `aria-hidden="false"` rather than removing the attribute (#28)
+- Uses documented methods for nested classes (4e58d45)
+- MenuBar no longer tracks internal Popup state (51ab17c)
 
 **Added**
 
 - Menu submenus can be instantiated as Disclosures by passing `collapse: true` (#27)
 - Uses the `hidden` attribute where `aria-hidden="true"` (#29)
+- Documents additional class properties
 
 **Removed**
 
@@ -20,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updates NPM dependencies (#25)
 - Corrects issues with the reliability of `destroy` methods (#26 & #31)
+- Corrects ambiguity with native DOM `firstChild` and `lastChild` properties (4795b2a, 1312a99)
 
 ## 0.2.0
 

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -106,6 +106,8 @@ class Dialog extends AriaComponent {
 ```javascript
 /**
  * The config.controller property.
+ *
+ * @type {HTMLButtonElement}
  */
 Dialog.controller
 ```
@@ -113,6 +115,8 @@ Dialog.controller
 ```javascript
 /**
  * The config.target property.
+ *
+ * @type {HTMLElement}
  */
 Dialog.target
 ```
@@ -120,8 +124,19 @@ Dialog.target
 ```javascript
 /**
  * The config.content property.
+ *
+ * @type {HTMLElement}
  */
 Dialog.content
+```
+
+```javascript
+/**
+ * The config.close property, or the button created in its absence.
+ *
+ * @type {HTMLButtonElement}
+ */
+Dialog.close
 ```
 
 ```javascript

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -238,6 +238,7 @@ export default class Dialog extends AriaComponent {
 
     if (this.popup.getState().expanded && keyCode === TAB) {
       const { activeElement } = document;
+      // @Todo Make a helper method to get these.
       const lastIndex = this.interactiveChildren.length - 1;
       const [firstChild] = this.interactiveChildren;
       const lastChild = this.interactiveChildren[lastIndex];

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -239,25 +239,25 @@ export default class Dialog extends AriaComponent {
 
     if (expanded && keyCode === TAB) {
       const { activeElement } = document;
-      // @Todo Make a helper method to get these.
-      const lastIndex = this.interactiveChildren.length - 1;
-      const [firstChild] = this.interactiveChildren;
-      const lastChild = this.interactiveChildren[lastIndex];
+      const [firstInteractiveChild] = this.interactiveChildren;
+      const lastInteractiveChild = (
+        this.interactiveChildren[this.interactiveChildren.length - 1]
+      );
 
-      if (shiftKey && firstChild === activeElement) {
+      if (shiftKey && firstInteractiveChild === activeElement) {
         event.preventDefault();
         /*
          * Move back from the first interactive child element to the last
          * interactive child element
          */
-        lastChild.focus();
-      } else if (! shiftKey && lastChild === activeElement) {
+        lastInteractiveChild.focus();
+      } else if (! shiftKey && lastInteractiveChild === activeElement) {
         event.preventDefault();
         /*
          * Move forward from the last interactive child element to the first
          * interactive child element.
          */
-        firstChild.focus();
+        firstInteractiveChild.focus();
       }
     }
   }

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -220,7 +220,7 @@ export default class Dialog extends AriaComponent {
    * @param {Event} event The Event object.
    */
   outsideClick(event) {
-    const { expanded } = this.popup.getState();
+    const { expanded } = this.state;
 
     if (expanded && ! this.target.contains(event.target)) {
       this.hide();
@@ -235,8 +235,9 @@ export default class Dialog extends AriaComponent {
   handleTargetKeydown(event) {
     const { TAB } = keyCodes;
     const { keyCode, shiftKey } = event;
+    const { expanded } = this.state;
 
-    if (this.popup.getState().expanded && keyCode === TAB) {
+    if (expanded && keyCode === TAB) {
       const { activeElement } = document;
       // @Todo Make a helper method to get these.
       const lastIndex = this.interactiveChildren.length - 1;

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -153,7 +153,7 @@ export default class Dialog extends AriaComponent {
      * to ensure values exists, but the interactive children will be collected
      * each time the dialog opens, in case the dialog's contents change.
      */
-    this.interactiveChildren = interactiveChildren(this.target);
+    this.interactiveChildElements = interactiveChildren(this.target);
 
     // Add event listeners.
     this.close.addEventListener('click', this.hide);
@@ -196,7 +196,7 @@ export default class Dialog extends AriaComponent {
   stateWasUpdated() {
     const { expanded } = this.state;
 
-    this.interactiveChildren = interactiveChildren(this.target);
+    this.interactiveChildElements = interactiveChildren(this.target);
 
     if (expanded) {
       this.content.setAttribute('aria-hidden', 'true');
@@ -239,9 +239,9 @@ export default class Dialog extends AriaComponent {
 
     if (expanded && keyCode === TAB) {
       const { activeElement } = document;
-      const [firstInteractiveChild] = this.interactiveChildren;
+      const [firstInteractiveChild] = this.interactiveChildElements;
       const lastInteractiveChild = (
-        this.interactiveChildren[this.interactiveChildren.length - 1]
+        this.interactiveChildElements[this.interactiveChildElements.length - 1]
       );
 
       if (shiftKey && firstInteractiveChild === activeElement) {

--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -74,7 +74,7 @@ describe('Disclosure with default configuration', () => {
       expect(target.getAttribute('hidden')).toEqual('');
 
       // Re-open the disclosure.
-      disclosure.setState({ expanded: true });
+      disclosure.open();
       // Should close on outside click.
       document.body.dispatchEvent(click);
       expect(disclosure.getState().expanded).toBeTruthy();
@@ -85,7 +85,7 @@ describe('Disclosure with default configuration', () => {
 
     it('Should update attributes when Return or Spacebar are pressed', () => {
       // Ensure the disclosure is closed.
-      disclosure.setState({ expanded: false });
+      disclosure.close();
 
       // Return to open.
       controller.dispatchEvent(keydownReturn);

--- a/src/Disclosure/README.md
+++ b/src/Disclosure/README.md
@@ -94,6 +94,8 @@ class Disclosure extends AriaComponent {
 ```javascript
 /**
  * The config.controller property.
+ *
+ * @type {HTMLButtonElement}
  */
 Disclosure.controller
 ```
@@ -101,6 +103,8 @@ Disclosure.controller
 ```javascript
 /**
  * The config.target property.
+ *
+ * @type {HTMLElement}
  */
 Disclosure.target
 ```

--- a/src/Listbox/README.md
+++ b/src/Listbox/README.md
@@ -79,6 +79,8 @@ class ListBox extends AriaComponent {
 ```javascript
 /**
  * The config.controller property.
+ *
+ * @type {HTMLButtonElement}
  */
 ListBox.controller
 ```
@@ -86,8 +88,37 @@ ListBox.controller
 ```javascript
 /**
  * The config.target property.
+ *
+ * @type {HTMLUListElement}
  */
 ListBox.target
+```
+
+```javascript
+/**
+ * The target list items.
+ *
+ * @type {array}
+ */
+Listbox.options
+```
+
+```javascript
+/**
+ * The first Listbox option.
+ *
+ * @type {HTMLLIElement}
+ */
+ListBox.firstOption
+```
+
+```javascript
+/**
+ * The last Listbox option.
+ *
+ * @type {HTMLLIElement}
+ */
+ListBox.lastOption
 ```
 
 ```javascript

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -402,8 +402,8 @@ export default class ListBox extends AriaComponent {
    * Close the Listbox when focus is moved away from the target.
    */
   handleTargetBlur() {
-    const { expanded } = this.state;
-    if (expanded) {
+    // Use Popup state here, since the Popup drives the Listbox state.
+    if (this.popup.getState().expanded) {
       this.hide();
     }
   }

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -402,7 +402,8 @@ export default class ListBox extends AriaComponent {
    * Close the Listbox when focus is moved away from the target.
    */
   handleTargetBlur() {
-    if (this.popup.getState().expanded) {
+    const { expanded } = this.state;
+    if (expanded) {
       this.hide();
     }
   }

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -168,7 +168,7 @@ describe('Menu correctly responds to events', () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownSpace);
       expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstInteractiveChild);
-      expect(menuBar.getState().expanded).toBeTruthy();
+      expect(domElements.listFirstItem.popup.getState().expanded).toBeTruthy();
     });
 
   it('Should move focus to the first popup child with return key from Menu bar',
@@ -176,7 +176,7 @@ describe('Menu correctly responds to events', () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownReturn);
       expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstInteractiveChild);
-      expect(menuBar.getState().expanded).toBeTruthy();
+      expect(domElements.listFirstItem.popup.getState().expanded).toBeTruthy();
     });
 
   it('Should close the submenu on right arrow key on a menu item with no submenu', () => {
@@ -186,7 +186,7 @@ describe('Menu correctly responds to events', () => {
     domElements.sublistTwoThirdItem.focus();
     domElements.sublistTwoThirdItem.dispatchEvent(keydownRight);
     expect(document.activeElement).toEqual(domElements.listFourthItem);
-    expect(menuBar.getState().expanded).toBeFalsy();
+    expect(domElements.listThirdItem.popup.getState().expanded).toBeFalsy();
   });
 
   it('Should close the submenu on left arrow key on a menu item with no parent menu', () => {
@@ -196,7 +196,7 @@ describe('Menu correctly responds to events', () => {
     domElements.sublistTwoThirdItem.focus();
     domElements.sublistTwoThirdItem.dispatchEvent(keydownLeft);
     expect(document.activeElement).toEqual(domElements.listSecondItem);
-    expect(menuBar.getState().expanded).toBeFalsy();
+    expect(domElements.listThirdItem.popup.getState().expanded).toBeFalsy();
   });
 
   it('Should click the submenu item on spacebar or return key', () => {

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -167,7 +167,7 @@ describe('Menu correctly responds to events', () => {
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownSpace);
-      expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstChild);
+      expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstInteractiveChild);
       expect(menuBar.getState().expanded).toBeTruthy();
     });
 
@@ -175,7 +175,7 @@ describe('Menu correctly responds to events', () => {
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownReturn);
-      expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstChild);
+      expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstInteractiveChild);
       expect(menuBar.getState().expanded).toBeTruthy();
     });
 

--- a/src/MenuBar/README.md
+++ b/src/MenuBar/README.md
@@ -76,6 +76,15 @@ class MenuBar extends AriaComponent {
 MenuBar.menu
 ```
 
+```javascript
+/**
+ * Collected menubar links.
+ *
+ * @type {array}
+ */
+MenuBar.menuBarItems
+```
+
 ## Example
 
 ```html

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -324,7 +324,7 @@ export default class MenuBar extends AriaComponent {
 
           // Close the popup.
           if (popup) {
-            popup.setState({ expanded: false });
+            popup.hide();
           }
 
           this.setState({
@@ -346,7 +346,7 @@ export default class MenuBar extends AriaComponent {
           event.preventDefault();
 
           if (! popup.state.expanded) {
-            popup.setState({ expanded: true });
+            popup.show();
           }
 
           popup.firstInteractiveChild.focus();

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -349,7 +349,7 @@ export default class MenuBar extends AriaComponent {
             popup.setState({ expanded: true });
           }
 
-          popup.firstChild.focus();
+          popup.firstInteractiveChild.focus();
         }
 
         break;

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -109,7 +109,6 @@ export default class MenuBar extends AriaComponent {
     this.handleMenuBarClick = this.handleMenuBarClick.bind(this);
     this.handleMenuItemKeydown = this.handleMenuItemKeydown.bind(this);
     this.stateWasUpdated = this.stateWasUpdated.bind(this);
-    this.trackPopupState = this.trackPopupState.bind(this);
     this.destroy = this.destroy.bind(this);
 
     // Only initialize if we passed in a <ul>.
@@ -211,7 +210,6 @@ export default class MenuBar extends AriaComponent {
           controller,
           target,
           onInit: this.onPopupInit,
-          onStateChange: this.trackPopupState,
           type: 'menu',
         });
 
@@ -248,36 +246,12 @@ export default class MenuBar extends AriaComponent {
   }
 
   /**
-   * Refresh component state when Popup state is updated.
-   *
-   * @param {object} state The Popup state.
-   */
-  trackPopupState(state = {}) {
-    const { menubarItem } = this.state;
-    const popup = this.constructor.getPopupFromMenubarItem(menubarItem);
-    /*
-     * Use the current MenuBar state if there's no popup or if an expanded state
-     * was passed in, otherwise make sure to use the current popup's state.
-     */
-    const expanded = (
-      false === popup
-      || Object.prototype.hasOwnProperty.call(state, 'expanded')
-    ) ? state.expanded : popup.getState();
-
-    // Add the Popup state to this component's state.
-    this.state = Object.assign({ menubarItem, popup, expanded });
-  }
-
-  /**
    * Manage menubar state.
    *
    * @param {Object} state The component state.
    */
   stateWasUpdated() {
     const { menubarItem } = this.state;
-
-    // Make sure we're tracking the Popup state along with this.
-    this.trackPopupState();
 
     // Prevent tabbing to all but the currently-active menubar item.
     rovingTabIndex(this.menuBarItems, menubarItem);
@@ -304,7 +278,8 @@ export default class MenuBar extends AriaComponent {
       RETURN,
     } = keyCodes;
     const { keyCode } = event;
-    const { menubarItem, popup } = this.state;
+    const { menubarItem } = this.state;
+    const popup = this.constructor.getPopupFromMenubarItem(menubarItem);
 
     switch (keyCode) {
       /*

--- a/src/MenuButton/README.md
+++ b/src/MenuButton/README.md
@@ -87,6 +87,8 @@ class MenuButtton extends AriaComponent {
 ```javascript
 /**
  * The config.controller property.
+ *
+ * @type {HTMLButtonElement}
  */
 MenuButton.controller
 ```
@@ -94,6 +96,8 @@ MenuButton.controller
 ```javascript
 /**
  * The config.target property.
+ *
+ * @type {HTMLElement}
  */
 MenuButton.target
 ```
@@ -101,6 +105,8 @@ MenuButton.target
 ```javascript
 /**
  * The config.list property.
+ *
+ * @type {HTMLUListElement}
  */
 MenuButton.list
 ```

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -49,8 +49,8 @@ describe('Popup adds and manipulates DOM element attributes', () => {
   it('Should be instantiated as expected', () => {
     expect(popup).toBeInstanceOf(Popup);
 
-    expect(popup.firstChild).toEqual(domFirstChild);
-    expect(popup.lastChild).toEqual(domLastChild);
+    expect(popup.firstInteractiveChild).toEqual(domFirstChild);
+    expect(popup.lastInteractiveChild).toEqual(domLastChild);
 
     expect(popup.getState().expanded).toBeFalsy();
 

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -121,7 +121,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
 describe('Popup correctly responds to events', () => {
   // Ensure the popup is open before all tests.
   beforeEach(() => {
-    popup.setState({ expanded: true });
+    popup.show();
   });
 
   it('Should close the popup when the ESC key is pressed',

--- a/src/Popup/README.md
+++ b/src/Popup/README.md
@@ -88,6 +88,8 @@ class Popup extends AriaComonents {
 ```javascript
 /**
  * The config.controller property.
+ *
+ * @type {HTMLElement}
  */
 Popup.controller
 ```
@@ -95,8 +97,24 @@ Popup.controller
 ```javascript
 /**
  * The config.target property.
+ *
+ * @type {HTMLElement}
  */
 Popup.target
+
+/**
+ * The target's first interactive child element.
+ *
+ * @type {HTMLElement}
+ */
+Popup.firstInteractiveChild
+
+/**
+ * The target's last interactive child element.
+ *
+ * @type {HTMLElement}
+ */
+Popup.lastInteractiveChild
 ```
 
 ## Example

--- a/src/Popup/README.md
+++ b/src/Popup/README.md
@@ -11,7 +11,7 @@ const config = {
   /**
    * The element used to trigger the Popup element.
    *
-   * @type {HTMLElement}
+   * @type {HTMLButtonElement}
    */
   controller: null,
 
@@ -89,7 +89,7 @@ class Popup extends AriaComonents {
 /**
  * The config.controller property.
  *
- * @type {HTMLElement}
+ * @type {HTMLButtonElement}
  */
 Popup.controller
 ```

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -135,12 +135,12 @@ export default class Popup extends AriaComponent {
      * them in as instance properties.
      */
     if (0 < this.interactiveChildElements.length) {
-      const [firstChild] = this.interactiveChildElements;
-      const lastChild = (
+      const [firstInteractiveChild] = this.interactiveChildElements;
+      const lastInteractiveChild = (
         this.interactiveChildElements[this.interactiveChildElements.length - 1]
       );
 
-      Object.assign(this, { firstChild, lastChild });
+      Object.assign(this, { firstInteractiveChild, lastInteractiveChild });
     }
 
     // Add target attribute.
@@ -257,7 +257,7 @@ export default class Popup extends AriaComponent {
          * the default behavior in most cases, but this patches the behavior in
          * cases where the markup is disconnected or out-of-order.
          */
-        this.firstChild.focus();
+        this.firstInteractiveChild.focus();
       }
     }
   }
@@ -289,7 +289,7 @@ export default class Popup extends AriaComponent {
       this.controller.focus();
     } else if (TAB === keyCode) {
       if (shiftKey) {
-        if ([this.firstChild, this.target].includes(activeElement)) {
+        if ([this.firstInteractiveChild, this.target].includes(activeElement)) {
           event.preventDefault();
           /*
            * Move focus back to the controller if the Shift key is pressed with
@@ -298,7 +298,7 @@ export default class Popup extends AriaComponent {
            */
           this.controller.focus();
         }
-      } else if (this.lastChild === activeElement) {
+      } else if (this.lastInteractiveChild === activeElement) {
         /*
          * Close the Popup when tabbing from the last child.
          */

--- a/src/Tablist/README.md
+++ b/src/Tablist/README.md
@@ -11,7 +11,7 @@ const config = {
   /**
    * The UL parent of the Tablist tabs.
    *
-   * @type {HTMLElement}
+   * @type {HTMLUListElement}
    */
   tabs: null,
 
@@ -76,18 +76,30 @@ class Tablist extends AriaComponent {
 
 ```javascript
 /**
- * The config.tablist property.
+ * The config.tabs property.
+ *
+ * @type {HTMLUListElement}
  */
-Tablist.tablist
+Tablist.tabs
 ```
 
 ```javascript
 /**
  * The config.panels property.
+ *
+ * @type {array}
  */
 Tablist.panels
 ```
 
+```javascript
+/**
+ * Collected anchors from inside of each list items.
+ *
+ * @type {array}
+ */
+Tablist.tabLinks
+```
 
 ## Example
 

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -211,7 +211,7 @@ export default class Tablist extends AriaComponent {
     });
 
     // Save the active panel's interactive children.
-    this.interactiveChildren = interactiveChildren(this.panels[activeIndex]);
+    this.interactiveChildElements = interactiveChildren(this.panels[activeIndex]);
 
     // Run {initCallback}
     this.onInit.call(this);
@@ -252,8 +252,8 @@ export default class Tablist extends AriaComponent {
     this.panels[activeIndex].setAttribute('tabindex', '0');
 
     // Allow tabbing to the newly-active panel.
-    this.interactiveChildren = interactiveChildren(this.panels[activeIndex]);
-    tabIndexAllow(this.interactiveChildren);
+    this.interactiveChildElements = interactiveChildren(this.panels[activeIndex]);
+    tabIndexAllow(this.interactiveChildElements);
 
     // Run {stateChangeCallback}
     this.onStateChange.call(this, this.state);
@@ -269,7 +269,7 @@ export default class Tablist extends AriaComponent {
     const { activeIndex } = this.state;
     const { keyCode, shiftKey } = event;
     const { activeElement } = document;
-    const [firstInteractiveChild] = this.interactiveChildren;
+    const [firstInteractiveChild] = this.interactiveChildElements;
 
     if (keyCode === TAB && shiftKey) {
       if (activeElement === this.panels[activeIndex]) {

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -269,13 +269,13 @@ export default class Tablist extends AriaComponent {
     const { activeIndex } = this.state;
     const { keyCode, shiftKey } = event;
     const { activeElement } = document;
-    const [firstChild] = this.interactiveChildren;
+    const [firstInteractiveChild] = this.interactiveChildren;
 
     if (keyCode === TAB && shiftKey) {
       if (activeElement === this.panels[activeIndex]) {
         event.preventDefault();
         this.tabLinks[activeIndex].focus();
-      } else if (activeElement === firstChild) {
+      } else if (activeElement === firstInteractiveChild) {
         /*
          * Ensure navigating with Shift-TAB from the first interactive child of
          * the active panel returns focus to the active panel.


### PR DESCRIPTION
This updates documentation to include some useful properties and does some general housekeeping.

**Changed**
- Uses documented methods for nested classes (4e58d45)
- MenuBar no longer tracks internal Popup state (51ab17c)

**Added**
- Documents additional class properties

**Fixed**
- Corrects ambiguity with native DOM `firstChild` and `lastChild` properties (4795b2a, 1312a99)