### PR TITLE
Fix: Loosens MenuBar menuitems' markup requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.3.2
+
+**Fixed**
+
+- Loosens MenuBar menuitems' markup requirements (#48)
+
 ## 0.3.1
 
 **Changed**

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -16,7 +16,7 @@ const menubarMarkup = `
   <nav class="nav" aria-label="Menu Class Example">
     <ul class="menubar">
       <li>
-        <a class="first-item" href="example.com">Fruit</a>
+        <button class="first-item">Fruit</button>
         <ul class="sublist1">
           <li><a class="sublist1-first-item" href="example.com">Apples</a></li>
           <li><a class="sublist1-second-item" href="example.com">Bananas</a></li>
@@ -25,6 +25,7 @@ const menubarMarkup = `
       </li>
       <li><a class="second-item" href="example.com">Cake</a></li>
       <li>
+        <svg><use href="my-icon"></use></svg>
         <a class="third-item" href="example.com">Vegetables</a>
         <div class="not-a-list">
           <ul class="sublist2">

--- a/src/MenuBar/README.md
+++ b/src/MenuBar/README.md
@@ -87,10 +87,13 @@ MenuBar.menuBarItems
 
 ## Additional Notes
 
-If a menu item has a sibling, that sibling will be turned into a "submenu popup".
-If that element is not a UL element, the script will search the popup target with
-`Element.querySelector('ul')` and use that as the `list` passed to the `Menu` 
-component.
+The first anchor or button element found in each item will be used as the 
+`role="menuitem"`.
+
+If a `menuitem` has a `nextElementSibling`, that element will be turned into a 
+"submenu popup". If a submenu popup's element is not a UL element, the script 
+will search the popup target with `Element.querySelector('ul')` and use that as 
+the `list` passed to the `Menu` component.
 
 ## Example
 

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -144,9 +144,18 @@ export default class MenuBar extends AriaComponent {
      * @type {array}
      */
     this.menuBarItems = this.menuBarChildren.reduce((acc, item) => {
-      const itemLink = item.firstElementChild;
+      const [firstChild, ...theRest] = Array.from(item.children);
 
-      if (null !== itemLink && 'A' === itemLink.nodeName) {
+      // Try to use the first child of the menu item.
+      let itemLink = firstChild;
+
+      // If the first child isn't a link or button, find the first instance of either.
+      if (null === itemLink || ! itemLink.matches('a,button')) {
+        [itemLink] = Array.from(theRest)
+          .filter((child) => child.matches('a,button'));
+      }
+
+      if (undefined !== itemLink) {
         return [...acc, itemLink];
       }
 
@@ -155,6 +164,7 @@ export default class MenuBar extends AriaComponent {
 
     /**
      * Initialize search.
+     *
      * @type {Search}
      */
     this.search = new Search(this.menuBarItems);


### PR DESCRIPTION
Fixes an issue where the first element of the menu item had to
be a link. It will now use the first link or button it finds.