### PR TITLE
Refactor: Extend Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Fixed**
 
 - MenuButton could attempt to focus the first Menu child even when the Popup is closed ()
+- Component callbacks could be run more than once ()
 
 **Removed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changes constructor parameters to accept a component element and an object of options (#51)
 - Requires activating elements to have a target attribute matching the ID value of the target element (#51)
 - Dialog focuses the target element on open (#51)
+- Dialog, MenuButton, and ListBox now _extend_ Popup, rather than using it internally ()
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Fixed**
 
+- MenuButton could attempt to focus the first Menu child even when the Popup is closed ()
+
 **Removed**
 
 - Dialog no longer requires a close button, and will not create one (#51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changes constructor parameters to accept a component element and an object of options (#51)
 - Requires activating elements to have a target attribute matching the ID value of the target element (#51)
 - Dialog focuses the target element on open (#51)
-- Dialog, MenuButton, and ListBox now _extend_ Popup, rather than using it internally ()
+- Dialog, MenuButton, and ListBox now _extend_ Popup, rather than using it internally (#54)
 
 **Added**
 
@@ -19,13 +19,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Fixed**
 
-- MenuButton could attempt to focus the first Menu child even when the Popup is closed ()
-- Component callbacks could be run more than once ()
+- MenuButton could attempt to focus the first Menu child even when the Popup is closed (14599f0)
+- Component callbacks could be run more than once (#54)
 
 **Removed**
 
 - Dialog no longer requires a close button, and will not create one (#51)
-- Popup no longer accepts `onInit` and `onDestroy` callbacks; additionally, MenuBar no longer acepts `onPopupInit` ()
+- Popup no longer accepts `onInit` and `onDestroy` callbacks; additionally, MenuBar no longer acepts `onPopupInit` (#54)
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Removed**
 
 - Dialog no longer requires a close button, and will not create one (#51)
+- Popup no longer accepts `onInit` and `onDestroy` callbacks; additionally, MenuBar no longer acepts `onPopupInit` ()
 
 ## 0.3.2
 

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -118,13 +118,16 @@ export default class AriaComponent {
    * Set a reference to the class instance on the element upon which the class
    * is instantiated.
    *
-   * @param {array} elements An array of elements upon which to add a reference to `this`.
+   * @param {array}  elements An array of elements upon which to add a reference to `this`.
+   * @param {string} propName Override the string description.
    */
-  setSelfReference(elements) {
+  setSelfReference(elements, propName) {
+    const name = propName || this.stringDescription.toLowerCase();
+
     const referenceElements = [...elements].map((element) => {
       Object.defineProperty(
         element,
-        this.stringDescription.toLowerCase(),
+        name,
         { value: this, configurable: true }
       );
 

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -112,6 +112,9 @@ export default class AriaComponent {
     if ('function' === typeof this.stateWasUpdated) {
       this.stateWasUpdated(Object.keys(newState));
     }
+
+    // Run {stateChangeCallback}
+    this.onStateChange.call(this, this.state);
   }
 
   /**

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -110,7 +110,7 @@ export default class AriaComponent {
     Object.assign(this.state, newState);
 
     if ('function' === typeof this.stateWasUpdated) {
-      this.stateWasUpdated();
+      this.stateWasUpdated(Object.keys(newState));
     }
   }
 

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -78,7 +78,7 @@ describe('Dialog with default configuration', () => {
       expect(target.dialog).toBeInstanceOf(Dialog);
       expect(modal.getState().expanded).toBeFalsy();
 
-      expect(onInit).toHaveBeenCalled();
+      expect(onInit).toHaveBeenCalledTimes(1);
     });
 
     it('Should add the correct attributes',
@@ -95,12 +95,14 @@ describe('Dialog with default configuration', () => {
       modal.show();
       expect(modal.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(target);
-      expect(onStateChange).toHaveBeenCalled();
+      // @todo Failing.
+      // expect(onStateChange).toHaveBeenCalledTimes(1);
 
       modal.hide();
       expect(modal.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-      expect(onStateChange).toHaveBeenCalled();
+      // @todo Failing.
+      // expect(onStateChange).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -162,7 +164,7 @@ describe('Dialog with default configuration', () => {
       expect(target.getAttribute('aria-hidden')).toBeNull();
       expect(target.getAttribute('hidden')).toBeNull();
 
-      expect(onDestroy).toHaveBeenCalled();
+      expect(onDestroy).toHaveBeenCalledTimes(1);
 
       // Quick and dirty verification that the original markup is restored.
       expect(document.body.innerHTML).toEqual(dialogMarkup);

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -1,4 +1,4 @@
-import { Dialog, Popup } from 'root';
+import { Dialog } from 'root';
 import { events } from '../lib/events';
 
 const {
@@ -63,7 +63,7 @@ const modal = new Dialog(
 
 describe('Dialog with default configuration', () => {
   beforeEach(() => {
-    modal.popup.hide();
+    modal.hide();
   });
 
   describe('Dialog adds and manipulates DOM element attributes', () => {
@@ -74,7 +74,8 @@ describe('Dialog with default configuration', () => {
       expect(controller.dialog).toBeInstanceOf(Dialog);
       expect(target.dialog).toBeInstanceOf(Dialog);
 
-      expect(modal.popup).toBeInstanceOf(Popup);
+      expect(controller.dialog).toBeInstanceOf(Dialog);
+      expect(target.dialog).toBeInstanceOf(Dialog);
       expect(modal.getState().expanded).toBeFalsy();
 
       expect(onInit).toHaveBeenCalled();
@@ -105,7 +106,7 @@ describe('Dialog with default configuration', () => {
 
   describe('Dialog correctly responds to events', () => {
     beforeEach(() => {
-      modal.popup.show();
+      modal.show();
     });
 
     it('Should update attributes when the controller is clicked', () => {

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -95,14 +95,13 @@ describe('Dialog with default configuration', () => {
       modal.show();
       expect(modal.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(target);
-      // @todo Failing.
-      // expect(onStateChange).toHaveBeenCalledTimes(1);
+      // beforeEach * 3 + 1 from modal.show().
+      expect(onStateChange).toHaveBeenCalledTimes(4);
 
       modal.hide();
       expect(modal.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-      // @todo Failing.
-      // expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -146,9 +146,6 @@ export default class Dialog extends Popup {
       document.body.removeEventListener('keydown', this.handleKeydownEsc);
       this.controller.focus();
     }
-
-    /* Run {stateChangeCallback} */
-    this.onStateChange.call(this, this.state);
   }
 
   /**
@@ -219,6 +216,9 @@ export default class Dialog extends Popup {
    * Destroy the Dialog and Popup.
    */
   destroy() {
+    // Destroy the Popup.
+    super.destroy();
+
     // Remove the `aria-hidden` attribute from the content wrapper.
     const contentLength = this.content.length;
     for (let i = 0; i < contentLength; i += 1) {
@@ -231,9 +231,6 @@ export default class Dialog extends Popup {
     // Remove event listeners.
     this.target.removeEventListener('keydown', this.targetHandleKeydown);
     document.body.removeEventListener('keydown', this.handleKeydownEsc);
-
-    // Destroy the Popup.
-    super.destroy();
 
     /* Run {destroyCallback} */
     this.onDestroy.call(this);

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,4 +1,3 @@
-import AriaComponent from '../AriaComponent';
 import Popup from '../Popup';
 import interactiveChildren from '../lib/interactiveChildren';
 import keyCodes from '../lib/keyCodes';
@@ -8,7 +7,7 @@ import toArray from '../lib/toArray';
 /**
  * Class to set up an interactive Dialog element.
  */
-export default class Dialog extends AriaComponent {
+export default class Dialog extends Popup {
   /**
    * Create a Dialog.
    * @constructor
@@ -17,7 +16,8 @@ export default class Dialog extends AriaComponent {
    * @param {object}      options    The options object.
    */
   constructor(controller, options = {}) {
-    super(controller);
+    // Pass in the `dialog` type.
+    super(controller, { type: 'dialog' });
 
     /**
      * The string description for this object.
@@ -25,9 +25,6 @@ export default class Dialog extends AriaComponent {
      * @type {string}
      */
     this[Symbol.toStringTag] = 'Dialog';
-
-    this.controller = controller;
-    this.target = super.constructor.getTargetElement(controller);
 
     /**
      * Options shape.
@@ -66,16 +63,12 @@ export default class Dialog extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods
-    this.onPopupStateChange = this.onPopupStateChange.bind(this);
     this.targetHandleKeydown = this.targetHandleKeydown.bind(this);
     this.handleKeydownEsc = this.handleKeydownEsc.bind(this);
-    this.show = this.show.bind(this);
-    this.hide = this.hide.bind(this);
     this.destroy = this.destroy.bind(this);
-    this.stateWasUpdated = this.stateWasUpdated.bind(this);
 
     this.init();
   }
@@ -84,6 +77,8 @@ export default class Dialog extends AriaComponent {
    * Set the component's DOM attributes and event listeners.
    */
   init() {
+    super.init();
+
     // Get the content items if none are provided.
     if (0 === this.content.length || undefined === this.content) {
       this.content = Array.from(document.body.children)
@@ -94,7 +89,8 @@ export default class Dialog extends AriaComponent {
 
     // If no content is found.
     if (0 === this.content.length) {
-      AriaComponent.configurationError(
+      Object.getPrototypeOf(Popup).configurationError.call(
+        this,
         'The Dialog target should not be within the main site content'
       );
     }
@@ -105,28 +101,8 @@ export default class Dialog extends AriaComponent {
      */
     super.setSelfReference([this.controller, this.target]);
 
-    /**
-     * The Popup instance controlling the Dialog.
-     *
-     * @type {Popup}
-     */
-    this.popup = new Popup(
-      this.controller,
-      {
-        type: 'dialog',
-        onStateChange: this.onPopupStateChange,
-      }
-    );
-
     // Allow focus on the target element.
     this.target.setAttribute('tabindex', '0');
-
-    /*
-     * Collect the Dialog's interactive child elements. This is an initial pass
-     * to ensure values exists, but the interactive children will be collected
-     * each time the dialog opens, in case the dialog's contents change.
-     */
-    this.interactiveChildElements = interactiveChildren(this.target);
 
     // Add event listeners.
     this.target.addEventListener('keydown', this.targetHandleKeydown);
@@ -135,29 +111,13 @@ export default class Dialog extends AriaComponent {
      * Remove clashing Popup event listener. This Popup event listener is
      * clashing with the Dialog's ability to trap keyboard tabs.
      */
-    this.popup.target.removeEventListener(
+    this.target.removeEventListener(
       'keydown',
-      this.popup.targetHandleKeydown
+      this.popupTargetKeydown
     );
-
-    /**
-     * Set initial state.
-     *
-     * @type {object}
-     */
-    this.state = { expanded: false };
 
     /* Run {initCallback} */
     this.onInit.call(this);
-  }
-
-  /**
-   * Keep this component's state synced with the Popup's state.
-   *
-   * @param {Object} state The Popup state.
-   */
-  onPopupStateChange({ expanded }) {
-    this.setState({ expanded });
   }
 
   /**
@@ -166,6 +126,8 @@ export default class Dialog extends AriaComponent {
    * @param {Object} state The component state.
    */
   stateWasUpdated() {
+    super.stateWasUpdated();
+
     const { expanded } = this.state;
     const contentLength = this.content.length;
 
@@ -257,12 +219,6 @@ export default class Dialog extends AriaComponent {
    * Destroy the Dialog and Popup.
    */
   destroy() {
-    // Remove the references to the class instance.
-    this.deleteSelfReferences();
-
-    // Destroy the Dialog Popup.
-    this.popup.destroy();
-
     // Remove the `aria-hidden` attribute from the content wrapper.
     const contentLength = this.content.length;
     for (let i = 0; i < contentLength; i += 1) {
@@ -276,21 +232,10 @@ export default class Dialog extends AriaComponent {
     this.target.removeEventListener('keydown', this.targetHandleKeydown);
     document.body.removeEventListener('keydown', this.handleKeydownEsc);
 
+    // Destroy the Popup.
+    super.destroy();
+
     /* Run {destroyCallback} */
     this.onDestroy.call(this);
-  }
-
-  /**
-   * Show the Dialog.
-   */
-  show() {
-    this.popup.show();
-  }
-
-  /**
-   * Hide the Dialog.
-   */
-  hide() {
-    this.popup.hide();
   }
 }

--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -144,6 +144,26 @@ describe('Disclosure with non-default configuration', () => {
     );
   });
 
+  it('Should run class methods and subscriber functions', () => {
+    expect(onInit).toHaveBeenCalledTimes(1);
+
+    disclosure.open();
+    expect(disclosure.getState().expanded).toBeTruthy();
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+
+    disclosure.close();
+    expect(disclosure.getState().expanded).toBeFalsy();
+    expect(onStateChange).toHaveBeenCalledTimes(2);
+
+    disclosure.destroy();
+    expect(disclosure.controller.disclosure).toBeUndefined();
+    expect(disclosure.target.disclosure).toBeUndefined();
+    expect(onDestroy).toHaveBeenCalledTimes(1);
+
+    // Quick and dirty verification that the original markup is restored.
+    expect(document.body.innerHTML).toEqual(disclosureMarkup);
+  });
+
   it('Should load open', () => {
     expect(disclosure.getState().expanded).toBeTruthy();
   });
@@ -154,25 +174,5 @@ describe('Disclosure with non-default configuration', () => {
     expect(controller.getAttribute('aria-expanded')).toEqual('false');
     expect(target.getAttribute('aria-hidden')).toEqual('true');
     expect(target.getAttribute('hidden')).toEqual('');
-  });
-
-  it('Should run class methods and subscriber functions', () => {
-    expect(onInit).toHaveBeenCalled();
-
-    disclosure.open();
-    expect(disclosure.getState().expanded).toBeTruthy();
-    expect(onStateChange).toHaveBeenCalled();
-
-    disclosure.close();
-    expect(disclosure.getState().expanded).toBeFalsy();
-    expect(onStateChange).toHaveBeenCalled();
-
-    disclosure.destroy();
-    expect(disclosure.controller.disclosure).toBeUndefined();
-    expect(disclosure.target.disclosure).toBeUndefined();
-    expect(onDestroy).toHaveBeenCalled();
-
-    // Quick and dirty verification that the original markup is restored.
-    expect(document.body.innerHTML).toEqual(disclosureMarkup);
   });
 });

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -74,7 +74,7 @@ export default class Disclosure extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Initial component state.
     this.state = { expanded: this.loadOpen };

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -206,9 +206,6 @@ export default class Disclosure extends AriaComponent {
     } else {
       tabIndexDeny(this.interactiveChildElements);
     }
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
   }
 
   /**

--- a/src/Listbox/Listbox.test.js
+++ b/src/Listbox/Listbox.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { Listbox, Popup } from 'root';
+import { Listbox } from 'root';
 import { events } from '../lib/events';
 
 const {
@@ -11,6 +11,8 @@ const {
   keydownDown,
   keydownHome,
   keydownEnd,
+  keyUpUp,
+  keyUpDown,
 } = events;
 
 const listboxMarkup = `
@@ -63,7 +65,7 @@ describe('Listbox with default configuration', () => {
       const [firstListItem] = listItems;
       expect(listbox.getState().activeDescendant).toEqual(firstListItem);
 
-      expect(controller.popup).toBeInstanceOf(Popup);
+      // expect(controller.popup).toBeInstanceOf(Popup);
 
       expect(controller.listbox).toBeInstanceOf(Listbox);
       expect(target.listbox).toBeInstanceOf(Listbox);
@@ -111,17 +113,15 @@ describe('Listbox with default configuration', () => {
     });
 
     it('Should open the popup on controller DOWN arrow key', () => {
-      controller.dispatchEvent(keydownDown);
+      controller.dispatchEvent(keyUpDown);
       expect(document.activeElement).toEqual(target);
-      // @todo Why does this fail?!?!
-      // expect(listbox.getState().expanded).toBeTruthy();
+      expect(listbox.getState().expanded).toBeTruthy();
     });
 
     it('Should open the popup on controller UP arrow key', () => {
-      controller.dispatchEvent(keydownUp);
+      controller.dispatchEvent(keyUpUp);
       expect(document.activeElement).toEqual(target);
-      // @todo Why does this fail?!?!
-      // expect(listbox.getState().expanded).toBeTruthy();
+      expect(listbox.getState().expanded).toBeTruthy();
     });
   });
 
@@ -148,7 +148,7 @@ describe('Listbox with default configuration', () => {
       expect(document.activeElement).toEqual(controller);
     });
 
-    it('Should set next element as activedescendant on target UP arrow key', () => {
+    it('Should set previous element as activedescendant on target UP arrow key', () => {
       listbox.setState({ activeDescendant: target.children[3] });
       expect(target.children[3].getAttribute('aria-selected')).toEqual('true');
 
@@ -160,7 +160,7 @@ describe('Listbox with default configuration', () => {
       expect(target.children[2].getAttribute('aria-selected')).toEqual('true');
     });
 
-    it('Should set previous element as activedescendant on target DOWN arrow key', () => {
+    it('Should set next element as activedescendant on target DOWN arrow key', () => {
       listbox.setState({ activeDescendant: target.children[4] });
       expect(target.children[4].getAttribute('aria-selected')).toEqual('true');
 

--- a/src/Listbox/Listbox.test.js
+++ b/src/Listbox/Listbox.test.js
@@ -65,12 +65,10 @@ describe('Listbox with default configuration', () => {
       const [firstListItem] = listItems;
       expect(listbox.getState().activeDescendant).toEqual(firstListItem);
 
-      // expect(controller.popup).toBeInstanceOf(Popup);
-
       expect(controller.listbox).toBeInstanceOf(Listbox);
       expect(target.listbox).toBeInstanceOf(Listbox);
 
-      expect(onInit).toHaveBeenCalled();
+      expect(onInit).toHaveBeenCalledTimes(1);
     });
 
     it('Should add the correct attributes', () => {
@@ -102,7 +100,7 @@ describe('Listbox with default configuration', () => {
       expect(target.getAttribute('aria-activedescendant')).toEqual(target.children[0].id);
       expect(document.activeElement).toEqual(target);
 
-      expect(onStateChange).toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -237,7 +235,7 @@ describe('Listbox with default configuration', () => {
       controller.dispatchEvent(click);
       expect(listbox.getState().expanded).toBeFalsy();
 
-      expect(onDestroy).toHaveBeenCalled();
+      expect(onDestroy).toHaveBeenCalledTimes(1);
 
       // Quick and dirty verification that the original markup is restored.
       // But first, restore the button's original text label.

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -63,7 +63,6 @@ export default class ListBox extends Popup {
     Object.assign(this, defaultOptions, options);
 
     // Bind class methods.
-    // this.start = this.start.bind(this);
     this.preventWindowScroll = this.preventWindowScroll.bind(this);
     this.controllerHandleKeyup = this.controllerHandleKeyup.bind(this);
     this.targetHandleKeydown = this.targetHandleKeydown.bind(this);
@@ -271,7 +270,7 @@ export default class ListBox extends Popup {
        * need to update state here; if the Listbox is open rest assured an
        * option is selected.
        */
-      // case ESC:
+      // ESC is handled via Popup.
       case RETURN:
       case SPACE: {
         event.preventDefault();

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -60,7 +60,7 @@ export default class ListBox extends Popup {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods.
     // this.start = this.start.bind(this);

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -19,7 +19,7 @@ export default class ListBox extends Popup {
    */
   constructor(controller, options = {}) {
     // Pass in the `listbox` type.
-    super(controller, { ...options, type: 'listbox' });
+    super(controller, { type: 'listbox' });
 
     /**
      * The string description for this object.

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -216,9 +216,6 @@ export default class ListBox extends Popup {
         this.controller.focus();
       }
     }
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
   }
 
   /**
@@ -387,6 +384,9 @@ export default class ListBox extends Popup {
    * Destroy the Listbox and Popup.
    */
   destroy() {
+    // Destroy the Popup.
+    super.destroy();
+
     // Remove the role attribute from each of the options.
     this.options.forEach((listItem) => {
       listItem.removeAttribute('role');
@@ -409,9 +409,6 @@ export default class ListBox extends Popup {
     this.target.removeEventListener('click', this.targetHandleClick);
     this.target.removeEventListener('blur', this.targetHandleBlur);
     window.removeEventListener('keydown', this.preventWindowScroll);
-
-    // Destroy the Popup.
-    super.destroy();
 
     // Run {destroyCallback}
     this.onDestroy.call(this);

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -93,7 +93,7 @@ describe('Menu collects DOM elements and adds attributes', () => {
     expect(domElements.sublistOne.menu).toBeInstanceOf(Menu);
     expect(domElements.sublistOne.menu.previousSibling).toEqual(domElements.listFirstItem);
 
-    expect(onInit).toHaveBeenCalled();
+    expect(onInit).toHaveBeenCalledTimes(1);
   });
 
   it('Should set element attributes correctly', () => {
@@ -203,7 +203,7 @@ describe('Destroying the Menu removes attributes', () => {
     expect(domElements.sublistOne.getAttribute('role')).toBeNull();
     expect(domElements.sublistTwoSecondItem.getAttribute('role')).toBeNull();
 
-    expect(onDestroy).toHaveBeenCalled();
+    expect(onDestroy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -88,7 +88,7 @@ export default class Menu extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods
     this.listHandleKeydown = this.listHandleKeydown.bind(this);

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -132,6 +132,7 @@ describe('Menu correctly responds to events', () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownLeft);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
+      expect(onStateChange).toHaveBeenCalledTimes(2);
     });
 
   it('Should move to the last list item with end key',
@@ -139,8 +140,7 @@ describe('Menu correctly responds to events', () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownEnd);
       expect(document.activeElement).toEqual(domElements.listLastItem);
-      // @todo Failing.
-      // expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledTimes(3);
     });
 
   it('Should move to the first list item with home key',

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -71,7 +71,6 @@ const domElements = {
 const onInit = jest.fn();
 const onStateChange = jest.fn();
 const onDestroy = jest.fn();
-const onPopupInit = jest.fn();
 const { list } = domElements;
 
 const menuBar = new MenuBar(
@@ -81,7 +80,6 @@ const menuBar = new MenuBar(
     onInit,
     onStateChange,
     onDestroy,
-    onPopupInit,
   }
 );
 
@@ -95,8 +93,6 @@ describe('Menu collects DOM elements and adds attributes', () => {
     expect(onInit).toHaveBeenCalledTimes(1);
 
     expect(domElements.listThirdItem.popup).toBeInstanceOf(Popup);
-    // @todo Failing.
-    // expect(onPopupInit).toHaveBeenCalledTimes(1);
   });
 
   it('Should add the correct DOM attributes and collect elements', () => {

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -92,10 +92,11 @@ describe('Menu collects DOM elements and adds attributes', () => {
     expect(domElements.list.menubar).toBeInstanceOf(MenuBar);
     expect(domElements.list.menubar.itemMatches).toEqual(':not(.exclude)');
 
-    expect(onInit).toHaveBeenCalled();
+    expect(onInit).toHaveBeenCalledTimes(1);
 
     expect(domElements.listThirdItem.popup).toBeInstanceOf(Popup);
-    expect(onPopupInit).toHaveBeenCalled();
+    // @todo Failing.
+    // expect(onPopupInit).toHaveBeenCalledTimes(1);
   });
 
   it('Should add the correct DOM attributes and collect elements', () => {
@@ -127,7 +128,7 @@ describe('Menu correctly responds to events', () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownRight);
       expect(document.activeElement).toEqual(domElements.listSecondItem);
-      expect(onStateChange).toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledTimes(1);
     });
 
   it('Should move to the previous sibling list item with left arrow key',
@@ -142,7 +143,8 @@ describe('Menu correctly responds to events', () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownEnd);
       expect(document.activeElement).toEqual(domElements.listLastItem);
-      expect(onStateChange).toHaveBeenCalled();
+      // @todo Failing.
+      // expect(onStateChange).toHaveBeenCalledTimes(1);
     });
 
   it('Should move to the first list item with home key',
@@ -214,7 +216,7 @@ describe('Menu correctly responds to events', () => {
     domElements.sublistOneSecondItem.addEventListener('click', onclick);
     domElements.sublistOneSecondItem.focus();
     domElements.sublistOneSecondItem.dispatchEvent(keydownSpace);
-    expect(onclick).toHaveBeenCalled();
+    expect(onclick).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -235,7 +237,7 @@ describe('Menu should destroy properly', () => {
     expect(domElements.sublistTwoLastItem.getAttribute('tabindex')).toBeNull();
 
     expect(domElements.list.menubar).toBeUndefined();
-    expect(onDestroy).toHaveBeenCalled();
+    expect(onDestroy).toHaveBeenCalledTimes(1);
 
     // Quick and dirty verification that the original markup is restored.
     expect(document.body.innerHTML).toEqual(menubarMarkup);

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -283,9 +283,6 @@ export default class MenuBar extends AriaComponent {
     rovingTabIndex(this.menuBarItems, menubarItem);
 
     menubarItem.focus();
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
   }
 
   /**

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -218,6 +218,9 @@ export default class MenuBar extends AriaComponent {
         }
       );
 
+      // Popup has to be instantiated.
+      popup.init();
+
       acc.popups.push(popup);
 
       const { target } = popup;

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -90,13 +90,6 @@ export default class MenuBar extends AriaComponent {
        * @callback destroyCallback
        */
       onDestroy: () => {},
-
-      /**
-       * Callback to run after Popup initializes.
-       *
-       * @callback popupInitCallback
-       */
-      onPopupInit: () => {},
     };
 
     // Merge remaining options with defaults and save all as instance properties.
@@ -212,10 +205,7 @@ export default class MenuBar extends AriaComponent {
 
       const popup = new Popup(
         controller,
-        {
-          onInit: this.onPopupInit,
-          type: 'menu',
-        }
+        { type: 'menu' }
       );
 
       // Popup has to be instantiated.

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -93,7 +93,7 @@ export default class MenuBar extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods.
     this.menubarHandleKeydown = this.menubarHandleKeydown.bind(this);

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -225,6 +225,10 @@ export default class MenuBar extends AriaComponent {
 
       const { target } = popup;
 
+      // Set Popup self-references.
+      Object.getPrototypeOf(popup).setSelfReference
+        .call(popup, [controller, target], 'popup');
+
       // If target isn't a UL, find the UL in target and use it.
       const list = ('UL' === target.nodeName)
         ? target

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { MenuButton, Popup, Menu } from 'root';
+import { MenuButton, Menu } from 'root';
 import { events } from '../lib/events';
 
 const {
@@ -55,8 +55,6 @@ describe('MenuButton adds and manipulates DOM element attributes', () => {
     expect(menuButton).toBeInstanceOf(MenuButton);
     expect(menuButton.toString()).toEqual('[object MenuButton]');
 
-    expect(controller.popup).toBeInstanceOf(Popup);
-    expect(target.popup).toBeInstanceOf(Popup);
     expect(list.menu).toBeInstanceOf(Menu);
 
     expect(menuButton.getState().expanded).toBeFalsy();

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -59,7 +59,7 @@ describe('MenuButton adds and manipulates DOM element attributes', () => {
 
     expect(menuButton.getState().expanded).toBeFalsy();
 
-    expect(onInit).toHaveBeenCalled();
+    expect(onInit).toHaveBeenCalledTimes(1);
   });
 
   it('Should add the correct attributes to the menuButton controller', () => {
@@ -82,10 +82,10 @@ describe('MenuButton adds and manipulates DOM element attributes', () => {
 
   it('Should run class methods and subscriber functions', () => {
     menuButton.show();
-    expect(onStateChange).toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenCalledTimes(1);
 
     menuButton.hide();
-    expect(onStateChange).toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -188,7 +188,7 @@ it('Should destroy the menuButton as expected', () => {
   controller.dispatchEvent(click);
   expect(menuButton.getState().expanded).toBeFalsy();
 
-  expect(onDestroy).toHaveBeenCalled();
+  expect(onDestroy).toHaveBeenCalledTimes(1);
 
   // Quick and dirty verification that the original markup is restored.
   expect(document.body.innerHTML).toEqual(menuButtonMarkup);

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -90,13 +90,9 @@ describe('MenuButton adds and manipulates DOM element attributes', () => {
 });
 
 describe('MenuButton correctly responds to events', () => {
-  // Ensure the menuButton is open before all tests.
-  beforeEach(() => {
-    menuButton.show();
-  });
-
   it('Should close the menuButton when the ESC key is pressed',
     () => {
+      menuButton.show();
       controller.focus();
       controller.dispatchEvent(keydownEsc);
       expect(menuButton.getState().expanded).toBeFalsy();
@@ -105,45 +101,50 @@ describe('MenuButton correctly responds to events', () => {
 
   it('Should move focus to the first menu item with Return key from controller',
     () => {
+      menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownReturn);
-      expect(document.activeElement)
-        .toEqual(domFirstChild);
+      expect(menuButton.getState().expanded).toBeTruthy();
+      expect(document.activeElement).toEqual(domFirstChild);
     });
 
   it('Should move focus to the first menu item with Spacebar from controller',
     () => {
+      menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownSpace);
-      expect(document.activeElement)
-        .toEqual(domFirstChild);
+      expect(menuButton.getState().expanded).toBeTruthy();
+      expect(document.activeElement).toEqual(domFirstChild);
     });
 
   it('Should move focus to the first menu item with down arrow from controller',
     () => {
+      menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownDown);
-      expect(document.activeElement)
-        .toEqual(domFirstChild);
+      expect(menuButton.getState().expanded).toBeTruthy();
+      expect(document.activeElement).toEqual(domFirstChild);
     });
 
   it('Should move focus to the last menu item with up arrow from controller',
     () => {
+      menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownUp);
-      expect(document.activeElement)
-        .toEqual(domLastChild);
+      expect(menuButton.getState().expanded).toBeTruthy();
+      expect(document.activeElement).toEqual(domLastChild);
     });
 
   it('Should move focus to the first menu child on TAB from controller',
     () => {
+      menuButton.show();
       controller.dispatchEvent(keydownTab);
-      expect(document.activeElement)
-        .toEqual(domFirstChild);
+      expect(document.activeElement).toEqual(domFirstChild);
     });
 
   it('Should close the menuButton and focus the controller when the ESC key is pressed',
     () => {
+      menuButton.show();
       target.dispatchEvent(keydownEsc);
       expect(menuButton.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
@@ -151,6 +152,7 @@ describe('MenuButton correctly responds to events', () => {
 
   it('Should close the menuButton when tabbing from the last child',
     () => {
+      menuButton.show();
       domLastChild.focus();
       target.dispatchEvent(keydownTab);
       expect(menuButton.getState().expanded).toBeFalsy();
@@ -158,6 +160,7 @@ describe('MenuButton correctly responds to events', () => {
 
   it('Should focus the controller when tabbing back from the first child',
     () => {
+      menuButton.show();
       domFirstChild.focus();
       target.dispatchEvent(keydownShiftTab);
       expect(document.activeElement).toEqual(controller);

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -137,6 +137,9 @@ export default class MenuButton extends Popup {
    * Destroy the Popup and Menu.
    */
   destroy() {
+    // Destroy the Popup.
+    super.destroy();
+
     // Destroy the Menu.
     this.menu.destroy();
 
@@ -146,7 +149,7 @@ export default class MenuButton extends Popup {
       this.controllerHandleKeydown
     );
 
-    // Destroy the MenuButton Popup.
-    super.destroy();
+    // Run {destroyCallback}
+    this.onDestroy.call(this);
   }
 }

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -39,6 +39,27 @@ export default class MenuButton extends Popup {
        * @type {HTMLUListElement}
        */
       list: null,
+
+      /**
+       * Callback to run after the component initializes.
+       *
+       * @callback initCallback
+       */
+      onInit: () => {},
+
+      /**
+       * Callback to run after component state is updated.
+       *
+       * @callback stateChangeCallback
+       */
+      onStateChange: () => {},
+
+      /**
+       * Callback to run after the component is destroyed.
+       *
+       * @callback destroyCallback
+       */
+      onDestroy: () => {},
     };
 
     // Merge remaining options with defaults and save all as instance properties.

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -17,7 +17,8 @@ export default class MenuButton extends Popup {
    * @param {object}      options    The options object.
    */
   constructor(controller, options = {}) {
-    super(controller);
+    // Pass in the `menu` type.
+    super(controller, { type: 'menu' });
 
     /**
      * The string description for this object.
@@ -25,9 +26,6 @@ export default class MenuButton extends Popup {
      * @type {string}
      */
     this[Symbol.toStringTag] = 'MenuButton';
-
-    this.controller = controller;
-    this.target = super.constructor.getTargetElement(controller);
 
     /**
      * Options shape.
@@ -41,36 +39,13 @@ export default class MenuButton extends Popup {
        * @type {HTMLUListElement}
        */
       list: null,
-
-      /**
-       * Callback to run after the component initializes.
-       *
-       * @callback initCallback
-       */
-      onInit: () => {},
-
-      /**
-       * Callback to run after component state is updated.
-       *
-       * @callback stateChangeCallback
-       */
-      onStateChange: () => {},
-
-      /**
-       * Callback to run after the component is destroyed.
-       *
-       * @callback destroyCallback
-       */
-      onDestroy: () => {},
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options, type: 'menu' });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods.
     this.controllerHandleKeydown = this.controllerHandleKeydown.bind(this);
-    this.show = this.show.bind(this);
-    this.hide = this.hide.bind(this);
     this.destroy = this.destroy.bind(this);
 
     this.init();
@@ -80,15 +55,23 @@ export default class MenuButton extends Popup {
    * Set up the component's DOM attributes and event listeners.
    */
   init() {
+    // Initialize Popup.
     super.init();
 
+    /*
+     * A reference to the class instance added to the controller and target
+     * elements to enable external interactions with this instance.
+     */
+    super.setSelfReference([this.controller, this.target]);
+
     /**
-     * The MenuButton is a Popup to present a Menu.
-     * 1. A HTMLUListElement was passed in as the `list` option
-     * 2. The Popup target is a HTMLUListElement
-     * 3. We find the first HTMLUListElement we inside the target
+     * The MenuButton is a Popup to present a Menu. The element used as the Menu
+     * is determined by the following "logic":
+     * 1. An HTMLUListElement was passed in as the `list` option
+     * 2. The Popup target is an HTMLUListElement
+     * 3. The first HTMLUListElement we inside the target
      *
-     * @type {Popup}
+     * @type {Menu}
      */
     if (null != this.list && 'UL' === this.list.nodeName) {
       this.menu = new Menu(this.list);
@@ -103,13 +86,6 @@ export default class MenuButton extends Popup {
     // Additional event listener(s).
     this.controller.addEventListener('keydown', this.controllerHandleKeydown);
 
-    /**
-     * Set initial state.
-     *
-     * @type {object}
-     */
-    this.state = { expanded: false };
-
     // Run {initCallback}
     this.onInit.call(this);
   }
@@ -120,8 +96,6 @@ export default class MenuButton extends Popup {
    * @param {Event} event The event object.
    */
   controllerHandleKeydown(event) {
-    super.controllerHandleKeydown(event);
-
     const { keyCode } = event;
     const {
       RETURN,

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -130,41 +130,32 @@ export default class MenuButton extends Popup {
       SPACE,
     } = keyCodes;
 
-    switch (keyCode) {
-      /*
-       * Open the menu and move focus to the first menu item.
-       */
-      case RETURN:
-      case SPACE:
-      case DOWN: {
-        event.preventDefault();
-        this.show();
+    if ([RETURN, SPACE, UP, DOWN].includes(keyCode)) {
+      event.preventDefault();
 
-        // Move focus to the first menu item.
-        if (this.menu.firstItem) {
+      // RETURN and SPACE are handled in the parent class.
+      if ([UP, DOWN].includes(keyCode)) {
+        this.toggle();
+      }
+
+      // Get fresh state.
+      const { expanded } = this.state;
+
+      /*
+       * UP moves to last menu item, the rest move to first menu item.
+       */
+      if (expanded) {
+        if (
+          [RETURN, SPACE, DOWN].includes(keyCode)
+          && null != this.menu.firstItem
+        ) {
           this.menu.firstItem.focus();
         }
 
-        break;
-      }
-
-      /*
-       * Opens the menu and move focus to the last menu item.
-       */
-      case UP: {
-        event.preventDefault();
-        this.show();
-
-        // Move focus to the last menu item.
-        if (this.menu.lastItem) {
+        if (keyCode === UP && null != this.menu.lastItem) {
           this.menu.lastItem.focus();
         }
-
-        break;
       }
-
-      default:
-        break;
     }
   }
 

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -1,4 +1,3 @@
-import AriaComponent from '../AriaComponent';
 import Popup from '../Popup';
 import Menu from '../Menu';
 import keyCodes from '../lib/keyCodes';
@@ -9,9 +8,9 @@ import keyCodes from '../lib/keyCodes';
  * https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
  * https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html
  */
-export default class MenuButton extends AriaComponent {
+export default class MenuButton extends Popup {
   /**
-   * Create a ListBox.
+   * Create a MenuButton.
    * @constructor
    *
    * @param {HTMLElement} controller The activating element.
@@ -66,11 +65,10 @@ export default class MenuButton extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, { ...defaultOptions, ...options, type: 'menu' });
 
     // Bind class methods.
     this.controllerHandleKeydown = this.controllerHandleKeydown.bind(this);
-    this.onPopupStateChange = this.onPopupStateChange.bind(this);
     this.show = this.show.bind(this);
     this.hide = this.hide.bind(this);
     this.destroy = this.destroy.bind(this);
@@ -82,22 +80,16 @@ export default class MenuButton extends AriaComponent {
    * Set up the component's DOM attributes and event listeners.
    */
   init() {
+    super.init();
+
     /**
-     * The MenuButton is basically a Popup to present a Menu, so we instantiate
-     * a Popup and subscribe to state changes to act on the MenuButton when the
-     * Popup is shown and hidden.
+     * The MenuButton is a Popup to present a Menu.
+     * 1. A HTMLUListElement was passed in as the `list` option
+     * 2. The Popup target is a HTMLUListElement
+     * 3. We find the first HTMLUListElement we inside the target
      *
      * @type {Popup}
      */
-    this.popup = new Popup(
-      this.controller,
-      {
-        type: 'menu',
-        onStateChange: this.onPopupStateChange,
-      }
-    );
-
-    // Initialize the Menu if we passed one in.
     if (null != this.list && 'UL' === this.list.nodeName) {
       this.menu = new Menu(this.list);
     } else if ('UL' === this.target.nodeName) {
@@ -123,23 +115,13 @@ export default class MenuButton extends AriaComponent {
   }
 
   /**
-   * Keep this component's state synced with the Popup's state.
-   *
-   * @param {Object} state The Popup state.
-   */
-  onPopupStateChange(state) {
-    this.setState(state);
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
-  }
-
-  /**
-   * Handle keydown events on the MenuButton controller.
+   * Handle additional keydown events on the MenuButton controller.
    *
    * @param {Event} event The event object.
    */
   controllerHandleKeydown(event) {
+    super.controllerHandleKeydown(event);
+
     const { keyCode } = event;
     const {
       RETURN,
@@ -190,9 +172,6 @@ export default class MenuButton extends AriaComponent {
    * Destroy the Popup and Menu.
    */
   destroy() {
-    // Destroy the MenuButton Popup.
-    this.popup.destroy();
-
     // Destroy the Menu.
     this.menu.destroy();
 
@@ -202,21 +181,7 @@ export default class MenuButton extends AriaComponent {
       this.controllerHandleKeydown
     );
 
-    // Run {destroyCallback}
-    this.onDestroy.call(this);
-  }
-
-  /**
-   * Show the menu Popup.
-   */
-  show() {
-    this.popup.show();
-  }
-
-  /**
-   * Hide the menu Popup.
-   */
-  hide() {
-    this.popup.hide();
+    // Destroy the MenuButton Popup.
+    super.destroy();
   }
 }

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -35,15 +35,15 @@ const target = document.querySelector('.wrapper');
 
 // Mock functions.
 const onStateChange = jest.fn();
-const onInit = jest.fn();
-const onDestroy = jest.fn();
+// const onInit = jest.fn();
+// const onDestroy = jest.fn();
 
 const popup = new Popup(
   controller,
   {
     onStateChange,
-    onInit,
-    onDestroy,
+    // onInit,
+    // onDestroy,
   }
 );
 
@@ -64,8 +64,6 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     popup.interactiveChildElements.forEach((link) => {
       expect(link.getAttribute('tabindex')).toEqual('-1');
     });
-
-    expect(onInit).toHaveBeenCalled();
   });
 
   it('Should add the correct attributes to the popup controller', () => {
@@ -208,8 +206,6 @@ describe('Popup destroy', () => {
 
     controller.dispatchEvent(click);
     expect(popup.getState().expanded).toBeFalsy();
-
-    expect(onDestroy).toHaveBeenCalled();
 
     // Quick and dirty verification that the original markup is restored.
     expect(document.body.innerHTML).toEqual(popupMarkup);

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -82,6 +82,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     // Click to open.
     controller.dispatchEvent(click);
     expect(popup.getState().expanded).toBeTruthy();
+    expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(controller.getAttribute('aria-expanded')).toEqual('true');
     expect(target.getAttribute('aria-hidden')).toEqual('false');
     expect(target.getAttribute('hidden')).toBeNull();
@@ -94,6 +95,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     // Click again to close.
     controller.dispatchEvent(click);
     expect(popup.getState().expanded).toBeFalsy();
+    expect(onStateChange).toHaveBeenCalledTimes(2);
     expect(controller.getAttribute('aria-expanded')).toEqual('false');
     expect(target.getAttribute('aria-hidden')).toEqual('true');
     expect(target.getAttribute('hidden')).toEqual('');
@@ -106,10 +108,10 @@ describe('Popup adds and manipulates DOM element attributes', () => {
 
   it('Should run class methods and subscriber functions', () => {
     popup.show();
-    expect(onStateChange).toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenCalledTimes(3);
 
     popup.hide();
-    expect(onStateChange).toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -35,16 +35,10 @@ const target = document.querySelector('.wrapper');
 
 // Mock functions.
 const onStateChange = jest.fn();
-// const onInit = jest.fn();
-// const onDestroy = jest.fn();
 
 const popup = new Popup(
   controller,
-  {
-    onStateChange,
-    // onInit,
-    // onDestroy,
-  }
+  { onStateChange }
 );
 
 // Popup has to be instanitated.

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -47,6 +47,9 @@ const popup = new Popup(
   }
 );
 
+// Popup has to be instanitated.
+popup.init();
+
 describe('Popup adds and manipulates DOM element attributes', () => {
   it('Should be instantiated as expected', () => {
     expect(popup).toBeInstanceOf(Popup);
@@ -56,9 +59,6 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     expect(popup.lastInteractiveChild).toEqual(domLastChild);
 
     expect(popup.getState().expanded).toBeFalsy();
-
-    expect(controller.popup).toBeInstanceOf(Popup);
-    expect(target.popup).toBeInstanceOf(Popup);
 
     // All interactive children should initially have a negative tabindex.
     popup.interactiveChildElements.forEach((link) => {

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -67,7 +67,7 @@ export default class Popup extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Intial component state.
     this.state = { expanded: false };
@@ -79,24 +79,16 @@ export default class Popup extends AriaComponent {
     this.show = this.show.bind(this);
     this.toggle = this.toggle.bind(this);
     this.popupControllerKeydown = this.popupControllerKeydown.bind(this);
-    this.targetHandleKeydown = this.targetHandleKeydown.bind(this);
+    this.popupTargetKeydown = this.popupTargetKeydown.bind(this);
     this.hideOnTabOut = this.hideOnTabOut.bind(this);
     this.hideOnOutsideClick = this.hideOnOutsideClick.bind(this);
     this.destroy = this.destroy.bind(this);
-
-    this.init();
   }
 
   /**
    * Set up the component's DOM attributes and event listeners.
    */
   init() {
-    /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
-     */
-    super.setSelfReference([this.controller, this.target]);
-
     /**
      * Collect the target element's interactive child elements.
      *
@@ -168,7 +160,7 @@ export default class Popup extends AriaComponent {
     // Add event listeners
     this.controller.addEventListener('click', this.toggle);
     this.controller.addEventListener('keydown', this.popupControllerKeydown);
-    this.target.addEventListener('keydown', this.targetHandleKeydown);
+    this.target.addEventListener('keydown', this.popupTargetKeydown);
     document.body.addEventListener('click', this.hideOnOutsideClick);
 
     // Run {initCallback}
@@ -257,7 +249,7 @@ export default class Popup extends AriaComponent {
    *
    * @param {Event} event The event object.
    */
-  targetHandleKeydown(event) {
+  popupTargetKeydown(event) {
     const { ESC, TAB } = keyCodes;
     const { keyCode, shiftKey } = event;
     const { expanded } = this.state;
@@ -371,7 +363,7 @@ export default class Popup extends AriaComponent {
       'keydown',
       this.popupControllerKeydown
     );
-    this.target.removeEventListener('keydown', this.targetHandleKeydown);
+    this.target.removeEventListener('keydown', this.popupTargetKeydown);
     document.body.removeEventListener('click', this.hideOnOutsideClick);
 
     // Reset initial state.

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -45,25 +45,11 @@ export default class Popup extends AriaComponent {
       type: 'true', // 'true' === 'menu' in UAs that don't support WAI-ARIA 1.1
 
       /**
-       * Callback to run after the component initializes.
-       *
-       * @callback initCallback
-       */
-      onInit: () => {},
-
-      /**
        * Callback to run after component state is updated.
        *
        * @callback stateChangeCallback
        */
       onStateChange: () => {},
-
-      /**
-       * Callback to run after the component is destroyed.
-       *
-       * @callback destroyCallback
-       */
-      onDestroy: () => {},
     };
 
     // Merge remaining options with defaults and save all as instance properties.

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -78,7 +78,7 @@ export default class Popup extends AriaComponent {
     this.hide = this.hide.bind(this);
     this.show = this.show.bind(this);
     this.controllerHandleClick = this.controllerHandleClick.bind(this);
-    this.controllerHandleKeydown = this.controllerHandleKeydown.bind(this);
+    this.popupControllerKeydown = this.popupControllerKeydown.bind(this);
     this.targetHandleKeydown = this.targetHandleKeydown.bind(this);
     this.hideOnTabOut = this.hideOnTabOut.bind(this);
     this.hideOnOutsideClick = this.hideOnOutsideClick.bind(this);
@@ -167,7 +167,7 @@ export default class Popup extends AriaComponent {
 
     // Add event listeners
     this.controller.addEventListener('click', this.controllerHandleClick);
-    this.controller.addEventListener('keydown', this.controllerHandleKeydown);
+    this.controller.addEventListener('keydown', this.popupControllerKeydown);
     this.target.addEventListener('keydown', this.targetHandleKeydown);
     document.body.addEventListener('click', this.hideOnOutsideClick);
 
@@ -210,7 +210,7 @@ export default class Popup extends AriaComponent {
    *
    * @param {Event} event The event object.
    */
-  controllerHandleKeydown(event) {
+  popupControllerKeydown(event) {
     const { expanded } = this.state;
     const {
       ESC,
@@ -379,7 +379,7 @@ export default class Popup extends AriaComponent {
     this.controller.removeEventListener('click', this.controllerHandleClick);
     this.controller.removeEventListener(
       'keydown',
-      this.controllerHandleKeydown
+      this.popupControllerKeydown
     );
     this.target.removeEventListener('keydown', this.targetHandleKeydown);
     document.body.removeEventListener('click', this.hideOnOutsideClick);

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -162,9 +162,6 @@ export default class Popup extends AriaComponent {
     this.controller.addEventListener('keydown', this.popupControllerKeydown);
     this.target.addEventListener('keydown', this.popupTargetKeydown);
     document.body.addEventListener('click', this.hideOnOutsideClick);
-
-    // Run {initCallback}
-    this.onInit.call(this);
   }
 
   /**
@@ -192,9 +189,6 @@ export default class Popup extends AriaComponent {
       // Focusable content should have tabindex='-1' or be removed from the DOM.
       tabIndexDeny(this.interactiveChildElements);
     }
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
   }
 
   /**
@@ -368,9 +362,6 @@ export default class Popup extends AriaComponent {
 
     // Reset initial state.
     this.state = { expanded: false };
-
-    // Run {destroyCallback}
-    this.onDestroy.call(this);
   }
 
   /**

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -77,7 +77,7 @@ export default class Popup extends AriaComponent {
     this.stateWasUpdated = this.stateWasUpdated.bind(this);
     this.hide = this.hide.bind(this);
     this.show = this.show.bind(this);
-    this.controllerHandleClick = this.controllerHandleClick.bind(this);
+    this.toggle = this.toggle.bind(this);
     this.popupControllerKeydown = this.popupControllerKeydown.bind(this);
     this.targetHandleKeydown = this.targetHandleKeydown.bind(this);
     this.hideOnTabOut = this.hideOnTabOut.bind(this);
@@ -166,7 +166,7 @@ export default class Popup extends AriaComponent {
     this.target.setAttribute('hidden', '');
 
     // Add event listeners
-    this.controller.addEventListener('click', this.controllerHandleClick);
+    this.controller.addEventListener('click', this.toggle);
     this.controller.addEventListener('keydown', this.popupControllerKeydown);
     this.target.addEventListener('keydown', this.targetHandleKeydown);
     document.body.addEventListener('click', this.hideOnOutsideClick);
@@ -221,11 +221,13 @@ export default class Popup extends AriaComponent {
     const { keyCode } = event;
 
     if ([SPACE, RETURN].includes(keyCode)) {
+      event.preventDefault();
+
       /*
        * Treat the Spacebar and Return keys as clicks in case the controller is
        * not a <button>.
        */
-      this.controllerHandleClick(event);
+      this.toggle(event);
     } else if (expanded) {
       if (ESC === keyCode) {
         event.preventDefault();
@@ -293,18 +295,6 @@ export default class Popup extends AriaComponent {
         this.hide();
       }
     }
-  }
-
-  /**
-   * Toggle the popup state.
-   *
-   * @param {Event} event The event object.
-   */
-  controllerHandleClick(event) {
-    event.preventDefault();
-    const { expanded } = this.state;
-
-    this.setState({ expanded: ! expanded });
   }
 
   /**
@@ -376,7 +366,7 @@ export default class Popup extends AriaComponent {
     tabIndexAllow(this.interactiveChildElements);
 
     // Remove event listeners.
-    this.controller.removeEventListener('click', this.controllerHandleClick);
+    this.controller.removeEventListener('click', this.toggle);
     this.controller.removeEventListener(
       'keydown',
       this.popupControllerKeydown
@@ -403,5 +393,14 @@ export default class Popup extends AriaComponent {
    */
   hide() {
     this.setState({ expanded: false });
+  }
+
+  /**
+   * Toggle the popup state.
+   */
+  toggle() {
+    const { expanded } = this.state;
+
+    this.setState({ expanded: ! expanded });
   }
 }

--- a/src/Tablist/Tablist.test.js
+++ b/src/Tablist/Tablist.test.js
@@ -94,7 +94,7 @@ describe('Tablist with default configuration', () => {
       expect(firstTab.tablist).toBeInstanceOf(Tablist);
       expect(secondPanel.tablist).toBeInstanceOf(Tablist);
 
-      expect(onInit).toHaveBeenCalled();
+      expect(onInit).toHaveBeenCalledTimes(1);
     });
 
     it('Should add the correct attributes and overlay element',
@@ -152,7 +152,7 @@ describe('Tablist with default configuration', () => {
       expect(secondPanel.getAttribute('tabindex')).toBeNull();
       expect(thirdPanel.getAttribute('tabindex')).toBeNull();
 
-      expect(onStateChange).toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledTimes(1);
 
       tablist.switchTo(2);
       expect(firstTab.getAttribute('aria-selected')).toBeNull();
@@ -174,7 +174,7 @@ describe('Tablist with default configuration', () => {
       expect(secondPanel.getAttribute('tabindex')).toBeNull();
       expect(thirdPanel.getAttribute('tabindex')).toEqual('0');
 
-      expect(onStateChange).toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledTimes(2);
     });
 
     it('Should remove all DOM attributes when destroyed', () => {
@@ -212,7 +212,7 @@ describe('Tablist with default configuration', () => {
       expect(firstTab.tablist).toBeUndefined();
       expect(secondPanel.tablist).toBeUndefined();
 
-      expect(onDestroy).toHaveBeenCalled();
+      expect(onDestroy).toHaveBeenCalledTimes(1);
     });
 
     // Quick and dirty verification that the original markup is restored.
@@ -273,7 +273,7 @@ describe('Tablist with default configuration', () => {
        * Increment the counter to track time spent trying to get these tests to
        * pass, even though they work as expected when tested in a browser.
        *
-       * Hours Lost: 4
+       * Hours Lost: 4.5
        */
       // const firstPanelChild = firstPanel.querySelector('a[href]');
 

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -250,9 +250,6 @@ export default class Tablist extends AriaComponent {
     // Allow tabbing to the newly-active panel.
     this.interactiveChildElements = interactiveChildren(this.panels[activeIndex]); // eslint-disable-line max-len
     tabIndexAllow(this.interactiveChildElements);
-
-    // Run {stateChangeCallback}
-    this.onStateChange.call(this, this.state);
   }
 
   /**

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -67,7 +67,7 @@ export default class Tablist extends AriaComponent {
     };
 
     // Merge remaining options with defaults and save all as instance properties.
-    Object.assign(this, { ...defaultOptions, ...options });
+    Object.assign(this, defaultOptions, options);
 
     // Bind class methods.
     this.panelHandleKeydown = this.panelHandleKeydown.bind(this);


### PR DESCRIPTION
Components that use Popup internally now extend the Popup class.

Additionally:
* `setState` now passes updated properties to `stateWasUpdated`
* MenuButton checks if it's open before focusing first child
* Ensure callbacks only run once
* `onStateChange` callback is run from within `setState`