### PR TITLE
Misc cleanup

### DIFF
--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -197,18 +197,17 @@ export default class AriaComponent {
    * Set a reference to the class instance on the element upon which the class
    * is instantiated.
    *
-   * @param {array}  elements An array of elements upon which to add a reference to `this`.
-   * @param {string} propName Override the string description.
+   * @param {HTMLElement} elements One or more elements upon which to add a reference to `this`.
    */
-  setSelfReference(elements, propName) {
-    const name = propName || this.stringDescription.toLowerCase();
-
-    const referenceElements = [...elements].map((element) => {
-      Object.defineProperty(
-        element,
-        name,
-        { value: this, configurable: true }
-      );
+  setSelfReference(...elements) {
+    const referenceElements = elements.map((element) => {
+      if (null !== element) {
+        Object.defineProperty(
+          element,
+          this.stringDescription.toLowerCase(),
+          { value: this, configurable: true }
+        );
+      }
 
       return element;
     });

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -201,13 +201,11 @@ export default class AriaComponent {
    */
   setSelfReference(...elements) {
     const referenceElements = elements.map((element) => {
-      if (null !== element) {
-        Object.defineProperty(
-          element,
-          this.stringDescription.toLowerCase(),
-          { value: this, configurable: true }
-        );
-      }
+      Object.defineProperty(
+        element,
+        this.stringDescription.toLowerCase(),
+        { value: this, configurable: true }
+      );
 
       return element;
     });

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -91,7 +91,7 @@ describe('Dialog with default configuration', () => {
       expect(target.getAttribute('hidden')).toEqual('');
 
       expect(target.getAttribute('role')).toEqual('dialog');
-      expect(target.getAttribute('aria-modal')).toEqual('true');
+      expect(target.getAttribute('aria-modal')).toBeNull();
     });
   });
 

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -105,10 +105,10 @@ export default class Dialog extends AriaComponent {
     }
 
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.controller, this.target]);
+    super.setSelfReference(this.controller, this.target);
 
     /*
      * Collect the Dialog's interactive child elements. This is an initial pass

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -159,7 +159,6 @@ export default class Dialog extends AriaComponent {
 
     // Set additional attributes.
     this.target.setAttribute('role', 'dialog');
-    this.target.setAttribute('aria-modal', 'true');
 
     // Add event listeners.
     this.controller.addEventListener('click', this.controllerHandleClick);
@@ -375,7 +374,6 @@ export default class Dialog extends AriaComponent {
     }
 
     this.target.removeAttribute('role');
-    this.target.removeAttribute('aria-modal');
 
     // Remove tabindex attribute.
     tabIndexAllow(this.interactiveChildElements);

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -83,10 +83,10 @@ export default class Disclosure extends AriaComponent {
    */
   init() {
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.controller, this.target]);
+    super.setSelfReference(this.controller, this.target);
 
     // Component state is initially set in the constructor.
     const { expanded } = this.state;

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -53,10 +53,10 @@ export default class ListBox extends Popup {
     super.init();
 
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.controller, this.target]);
+    super.setSelfReference(this.controller, this.target);
 
     /**
      * The target list items.

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -88,10 +88,10 @@ export default class Menu extends AriaComponent {
    */
   init() {
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.list]);
+    super.setSelfReference(this.list);
 
     /*
      * Add the 'menu' role to signify a widget that offers a list of choices to

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -89,10 +89,10 @@ export default class MenuBar extends AriaComponent {
    */
   init() {
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.list]);
+    super.setSelfReference(this.list);
 
     // Set the menu role.
     this.list.setAttribute('role', 'menubar');
@@ -199,7 +199,7 @@ export default class MenuBar extends AriaComponent {
 
       // Set Popup self-references.
       Object.getPrototypeOf(popup).setSelfReference
-        .call(popup, [controller, target], 'popup');
+        .call(popup, controller, target);
 
       // If target isn't a UL, find the UL in target and use it.
       const list = ('UL' === target.nodeName)

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -59,10 +59,10 @@ export default class MenuButton extends Popup {
     super.init();
 
     /*
-     * A reference to the class instance added to the controller and target
-     * elements to enable external interactions with this instance.
+     * Add a reference to the class instance to enable external interactions
+     * with this instance.
      */
-    super.setSelfReference([this.controller, this.target]);
+    super.setSelfReference(this.controller, this.target);
 
     /**
      * The MenuButton is a Popup to present a Menu. The element used as the Menu

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -125,10 +125,10 @@ export default class Tablist extends AriaComponent {
     // Set attributes for each tab.
     this.tabLinks.forEach((tab, index) => {
       /*
-       * A reference to the class instance added to the controller and target
-       * elements to enable external interactions with this instance.
+       * Add a reference to the class instance to enable external interactions
+       * with this instance.
        */
-      super.setSelfReference([tab]);
+      super.setSelfReference(tab);
 
       // Ensure each tab has an ID.
       setUniqueId(tab);
@@ -156,7 +156,7 @@ export default class Tablist extends AriaComponent {
        * Add a reference to the class instance to enable external interactions
        * with this instance.
        */
-      super.setSelfReference([panel]);
+      super.setSelfReference(panel);
 
       // Ensure each panel has an ID.
       setUniqueId(panel);


### PR DESCRIPTION
* Removes `aria-modal` from `Dialog`
* Updates `AriaComponent.setSelfReference` to accept a variable number of HTML Elements; removes the option to override the object's `stringDescription`