### PR TITLE
Uses `aria-controls` to associate component controller and target

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: 'latest',
+      version: 'detect',
     },
   },
   rules: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Changed**
 
 - Changes constructor parameters to accept a component element and an object of options (#51)
-- Requires activating elements to have a target attribute matching the ID value of the target element (#51)
-- MenuButton, and ListBox now _extend_ Popup, rather than using it internally (#54)
+- Requires activating elements to have an `aria-current` attribute matching the ID value of the target element (#51, #66)
+- MenuButton and ListBox now _extend_ Popup, rather than using it internally (#54)
 - Dialog is no longer a Popup (#59)
 - Dialog focuses the target element on open (#51)
 - Loosens MenuBar and Menu components' markup requirements (#48, 3385f2e)

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -3,19 +3,20 @@
  */
 export default class AriaComponent {
   /**
-   * Get the target element based on the controller's `target` attribute.
+   * Get the target element based on the controller's `aria-controls` attribute.
    *
    * @param  {HTMLElement} controller The component's controlling element.
    * @return {HTMLElement|null}
    */
   static getTargetElement(controller) {
-    if (! controller.hasAttribute('target')) {
+    if (! controller.hasAttribute('aria-controls')) {
       AriaComponent.configurationError(
-        'The component element is missing the required \'target\' attribute'
+        // eslint-disable-next-line max-len
+        'The component element is missing the required \'aria-controls\' attribute'
       );
     }
 
-    const targetId = controller.getAttribute('target');
+    const targetId = controller.getAttribute('aria-controls');
     const target = document.getElementById(targetId);
 
     if (null === target) {
@@ -42,12 +43,12 @@ export default class AriaComponent {
     }
 
     const targetId = target.id;
-    const controller = document.querySelector(`[target="${targetId}"]`);
+    const controller = document.querySelector(`[aria-controls="${targetId}"]`);
 
     if (null === controller) {
       AriaComponent.configurationError(
         // eslint-disable-next-line max-len
-        `A controlling element with \`target\` attribute of '${targetId}' is not found`
+        `A controlling element with \`aria-controls\` attribute of '${targetId}' is not found`
       );
     }
 

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -20,7 +20,7 @@ const dialogMarkup = `
       voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
       sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
       mollit anim id est laborum.</p>
-      <a target="dialog" class="link" href="#dialog">Open dialog</a>
+      <a aria-controls="dialog" class="link" href="#dialog">Open dialog</a>
     </article>
   </main>
   <footer class="site-footer">Site footer</footer>

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -20,7 +20,7 @@ Class for setting up an interactive Dialog element.
         sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.</p>
 
-        <button target="dialog">Open dialog</button>
+        <button aria-controls="dialog">Open dialog</button>
       </article>
     </main>
   </div>
@@ -52,7 +52,7 @@ Dialog(target = null, options = {});
 
 _**`target`**_ `HTMLElement`  
 > The element used as the Dialog; required to have an `id` attribute with a value  
-> matching the `target` attribute value of the controlling element.
+> matching the `aria-controls` attribute value of the controlling element.
 
 _**`options`**_ `object`  
 > Configuration options.

--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -59,18 +59,22 @@ describe('Disclosure with default configuration', () => {
       });
     });
 
-    it('Should add the correct attributes to the disclosure controller',
+    it(
+      'Should add the correct attributes to the disclosure controller',
       () => {
         expect(controller.getAttribute('aria-expanded')).toEqual('false');
         expect(controller.getAttribute('tabindex')).toBeNull();
         expect(controller.getAttribute('aria-owns')).toEqual(target.id);
-      });
+      }
+    );
 
-    it('Should add the correct attributes to the disclosure target',
+    it(
+      'Should add the correct attributes to the disclosure target',
       () => {
         expect(target.getAttribute('aria-hidden')).toEqual('true');
         expect(target.getAttribute('hidden')).toEqual('');
-      });
+      }
+    );
   });
 
   describe('Disclosure correctly responds to events', () => {

--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -11,7 +11,7 @@ const {
 const disclosureMarkup = `
   <dl>
     <dt>
-      <button target="answer">What is Lorem Ipsum?</button>
+      <button aria-controls="answer">What is Lorem Ipsum?</button>
     </dt>
     <dd id="answer">
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -62,7 +62,6 @@ describe('Disclosure with default configuration', () => {
     it('Should add the correct attributes to the disclosure controller',
       () => {
         expect(controller.getAttribute('aria-expanded')).toEqual('false');
-        expect(controller.getAttribute('aria-controls')).toEqual(target.id);
         expect(controller.getAttribute('tabindex')).toBeNull();
         expect(controller.getAttribute('aria-owns')).toEqual(target.id);
       });
@@ -139,7 +138,7 @@ describe('Disclosure with default configuration', () => {
 
     expect(controller.getAttribute('role')).toBeNull();
     expect(controller.getAttribute('aria-expanded')).toBeNull();
-    expect(controller.getAttribute('aria-controls')).toBeNull();
+    expect(controller.getAttribute('aria-controls')).toEqual(target.id);
     expect(controller.getAttribute('tabindex')).toBeNull();
     // The test markup isn't detatched, so this doesn't apply.
     expect(controller.getAttribute('aria-owns')).toBeNull();

--- a/src/Disclosure/README.md
+++ b/src/Disclosure/README.md
@@ -6,7 +6,7 @@ Class for independently revealing and hiding inline content.
 ## Example
 
 ```html
-<button target="disclosure">Open</button>
+<button aria-controls="disclosure">Open</button>
 <div id="disclosure">
   <ul>
     <li><a href="example.com"></a></li>
@@ -31,7 +31,7 @@ Disclosure(controller = null, options = {});
 ```
 
 _**`controller`**_ `HTMLElement`  
-> The element used to activate the Disclosure target; required to have a `target`  
+> The element used to activate the Disclosure target; required to have a `aria-controls`  
 attribute with a value matching the `id` attribute value of the target element.
 
 _**`options`**_ `object`  

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -104,7 +104,6 @@ export default class Disclosure extends AriaComponent {
 
     // Add controller attributes
     this.controller.setAttribute('aria-expanded', `${expanded}`);
-    this.controller.setAttribute('aria-controls', this.target.id);
 
     // Patch button role and behavior for non-button controller.
     if ('BUTTON' !== this.controller.nodeName) {
@@ -267,7 +266,6 @@ export default class Disclosure extends AriaComponent {
 
     // Remove controller attributes.
     this.controller.removeAttribute('aria-expanded');
-    this.controller.removeAttribute('aria-controls');
     this.controller.removeAttribute('aria-owns');
     this.controller.removeAttribute('tabindex');
 

--- a/src/Listbox/Listbox.test.js
+++ b/src/Listbox/Listbox.test.js
@@ -16,7 +16,7 @@ const {
 } = events;
 
 const listboxMarkup = `
-  <button target="options">Choose</button>
+  <button aria-controls="options">Choose</button>
   <ul id="options">
     <li>Anchorage</li>
     <li>Baltimore</li>

--- a/src/Listbox/Listbox.test.js
+++ b/src/Listbox/Listbox.test.js
@@ -253,7 +253,7 @@ describe('Listbox with default configuration', () => {
 
       expect(controller.getAttribute('aria-haspopup')).toBeNull();
       expect(controller.getAttribute('aria-expanded')).toBeNull();
-      expect(controller.getAttribute('aria-controls')).toBeNull();
+      expect(controller.getAttribute('aria-controls')).toEqual(target.id);
       expect(target.getAttribute('aria-activedescendant')).toBeNull();
       expect(target.getAttribute('aria-hidden')).toBeNull();
       expect(target.getAttribute('hidden')).toBeNull();

--- a/src/Listbox/README.md
+++ b/src/Listbox/README.md
@@ -6,7 +6,7 @@ Class for setting up an interactive Listbox element.
 ## Example
 
 ```html
-<button target="options">Choose</button>
+<button aria-controls="options">Choose</button>
 <ul id="options">
   <li>Anchorage</li>
   <li>Baltimore</li>
@@ -34,7 +34,7 @@ Listbox(controller = null, options = {});
 ```
 
 _**`controller`**_ `HTMLElement`  
-> The element used to activate the Listbox target; required to have a `target`  
+> The element used to activate the Listbox target; required to have a `aria-controls`  
 attribute with a value matching the `id` attribute value of the target element.
 
 ### Available Options

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -304,7 +304,7 @@ describe('Menu instatiates submenus as Disclosures', () => {
     expect(list.getAttribute('role')).toBeNull();
 
     expect(domElements.listFirstItem.getAttribute('aria-expanded')).toBeNull();
-    expect(domElements.listFirstItem.getAttribute('aria-controls')).toBeNull();
+    expect(domElements.listFirstItem.getAttribute('aria-controls')).toEqual(domElements.sublistOne.id);
     expect(domElements.listFirstItem.getAttribute('tabindex')).toBeNull();
     // The test markup isn't detatched, so this doesn't apply.
     expect(domElements.listFirstItem.getAttribute('aria-owns')).toBeNull();

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -119,61 +119,77 @@ describe('Menu collects DOM elements and adds attributes', () => {
 });
 
 describe('MenuItem correctly responds to events', () => {
-  it('Should move to the next sibling list item with down arrow key',
+  it(
+    'Should move to the next sibling list item with down arrow key',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownDown);
       expect(document.activeElement).toEqual(domElements.listSecondItem);
-    });
+    }
+  );
 
-  it('Should move to the first sibling list item with up arrow key from last item',
+  it(
+    'Should move to the first sibling list item with up arrow key from last item',
     () => {
       domElements.listLastItem.focus();
       domElements.listLastItem.dispatchEvent(keydownDown);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
-    });
+    }
+  );
 
-  it('Should move to the last list item with end key',
+  it(
+    'Should move to the last list item with end key',
     () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownEnd);
       expect(document.activeElement).toEqual(domElements.listLastItem);
-    });
+    }
+  );
 
-  it('Should move to the first list item with home key',
+  it(
+    'Should move to the first list item with home key',
     () => {
       domElements.listThirdItem.focus();
       domElements.listThirdItem.dispatchEvent(keydownHome);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
-    });
+    }
+  );
 
-  it('Should move to the previous sibling list item with up arrow key',
+  it(
+    'Should move to the previous sibling list item with up arrow key',
     () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownUp);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
-    });
+    }
+  );
 
-  it('Should move to the last sibling list item with up arrow key from first item',
+  it(
+    'Should move to the last sibling list item with up arrow key from first item',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownUp);
       expect(document.activeElement).toEqual(domElements.listLastItem);
-    });
+    }
+  );
 
-  it('Should move to the first sublist item with right arrow key',
+  it(
+    'Should move to the first sublist item with right arrow key',
     () => {
       domElements.listThirdItem.focus();
       domElements.listThirdItem.dispatchEvent(keydownRight);
       expect(document.activeElement).toEqual(domElements.sublistTwoFirstItem);
-    });
+    }
+  );
 
-  it('Should move to the parent list with left arrow key',
+  it(
+    'Should move to the parent list with left arrow key',
     () => {
       domElements.sublistTwoSecondItem.focus();
       domElements.sublistTwoSecondItem.dispatchEvent(keydownLeft);
       expect(document.activeElement).toEqual(domElements.listThirdItem);
-    });
+    }
+  );
 
   it('Should scope search to the current list', () => {
     domElements.sublistTwoLastItem.focus();
@@ -252,7 +268,8 @@ describe('Menu instatiates submenus as Disclosures', () => {
   });
 
   describe('MenuItem Disclosure correctly responds to events', () => {
-    it('Should expand the Disclosure and move to the first sublist item with right arrow key',
+    it(
+      'Should expand the Disclosure and move to the first sublist item with right arrow key',
       () => {
         domElements.listThirdItem.focus();
         domElements.listThirdItem.dispatchEvent(keydownRight);
@@ -267,15 +284,19 @@ describe('Menu instatiates submenus as Disclosures', () => {
           expect(detail.instance).toStrictEqual(domElements.listThirdItem.disclosure);
           expect(target).toStrictEqual(domElements.listThirdItem);
         });
-      });
+      }
+    );
 
-    it('Should move to the next sibling list item with down arrow key',
+    it(
+      'Should move to the next sibling list item with down arrow key',
       () => {
         domElements.sublistTwoFirstItem.dispatchEvent(keydownDown);
         expect(document.activeElement).toEqual(domElements.sublistTwoSecondItem);
-      });
+      }
+    );
 
-    it('Should collapse the Disclosure and move to the parent list with left arrow key',
+    it(
+      'Should collapse the Disclosure and move to the parent list with left arrow key',
       () => {
         domElements.sublistTwoSecondItem.dispatchEvent(keydownLeft);
         expect(domElements.listThirdItem.disclosure.getState().expanded).toBe(false);
@@ -289,13 +310,16 @@ describe('Menu instatiates submenus as Disclosures', () => {
           expect(detail.instance).toStrictEqual(domElements.listThirdItem.disclosure);
           expect(target).toStrictEqual(domElements.listThirdItem);
         });
-      });
+      }
+    );
 
-    it('Should move to the next sibling list item with down arrow key',
+    it(
+      'Should move to the next sibling list item with down arrow key',
       () => {
         domElements.listThirdItem.dispatchEvent(keydownDown);
         expect(document.activeElement).toEqual(domElements.listFourthItem);
-      });
+      }
+    );
   });
 
   it('Should remove all Menu Disclosure DOM attributes when destroyed', () => {

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -15,7 +15,7 @@ const menuMarkup = `
   <nav class="nav" aria-label="Menu Class Example">
     <ul class="menu">
       <li>
-        <button target="first-disclosure" class="first-item">Fruit</button>
+        <button aria-controls="first-disclosure" class="first-item">Fruit</button>
         <ul id="first-disclosure" class="sublist1">
           <li><a class="sublist1-first-item" href="example.com">Apples</a></li>
           <li><a class="sublist1-second-item" href="example.com">Bananas</a></li>
@@ -25,7 +25,7 @@ const menuMarkup = `
       <li><a class="second-item" href="example.com">Cake</a></li>
       <li>
         <svg><use href="my-icon"></use></svg>
-        <a target="second-disclosure" class="third-item" href="example.com">Vegetables</a>
+        <a aria-controls="second-disclosure" class="third-item" href="example.com">Vegetables</a>
         <ul id="second-disclosure" class="sublist2">
           <li><a class="sublist2-first-item" href="example.com">Carrots</a></li>
           <li><a class="sublist2-second-item" href="example.com">Broccoli</a></li>

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -170,7 +170,7 @@ export default class Menu extends AriaComponent {
       link.setAttribute('aria-posinset', index + 1);
 
       // Instantiate submenu Disclosures
-      if (this.collapse && link.hasAttribute('target')) {
+      if (this.collapse && link.hasAttribute('aria-controls')) {
         const disclosure = new Disclosure(
           link,
           { _stateDispatchesOnly: true }

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -122,7 +122,8 @@ describe('Menu collects DOM elements and adds attributes', () => {
 // Events:
 //    down moves into the sublist
 describe('Menu correctly responds to events', () => {
-  it('Should move to the next sibling list item with right arrow key',
+  it(
+    'Should move to the next sibling list item with right arrow key',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownRight);
@@ -140,61 +141,77 @@ describe('Menu correctly responds to events', () => {
         });
         expect(target).toStrictEqual(list);
       });
-    });
+    }
+  );
 
-  it('Should move to the previous sibling list item with left arrow key',
+  it(
+    'Should move to the previous sibling list item with left arrow key',
     () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownLeft);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
       expect(onStateChange).toHaveBeenCalledTimes(2);
-    });
+    }
+  );
 
-  it('Should move to the last list item with end key',
+  it(
+    'Should move to the last list item with end key',
     () => {
       domElements.listSecondItem.focus();
       domElements.listSecondItem.dispatchEvent(keydownEnd);
       expect(document.activeElement).toEqual(domElements.listLastItem);
       expect(onStateChange).toHaveBeenCalledTimes(3);
-    });
+    }
+  );
 
-  it('Should move to the first list item with home key',
+  it(
+    'Should move to the first list item with home key',
     () => {
       domElements.listThirdItem.focus();
       domElements.listThirdItem.dispatchEvent(keydownHome);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
-    });
+    }
+  );
 
-  it('Should move to the last sibling list item with left arrow key from first item',
+  it(
+    'Should move to the last sibling list item with left arrow key from first item',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownLeft);
       expect(document.activeElement).toEqual(domElements.listLastItem);
-    });
+    }
+  );
 
-  it('Should move to the first sibling list item with right arrow key from last item',
+  it(
+    'Should move to the first sibling list item with right arrow key from last item',
     () => {
       domElements.listLastItem.focus();
       domElements.listLastItem.dispatchEvent(keydownRight);
       expect(document.activeElement).toEqual(domElements.listFirstItem);
-    });
+    }
+  );
 
-  it('Should move focus to the first popup child with down arrow from Menu bar',
+  it(
+    'Should move focus to the first popup child with down arrow from Menu bar',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownDown);
       expect(document.activeElement).toEqual(domElements.sublistOneFirstItem);
-    });
+    }
+  );
 
-  it('Should move focus to the first popup child with spacebar from Menu bar',
+  it(
+    'Should move focus to the first popup child with spacebar from Menu bar',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownSpace);
       expect(document.activeElement).toEqual(domElements.listFirstItem.popup.firstInteractiveChild);
       expect(menuBar.getState().popup.getState().expanded).toBeTruthy();
-    });
+    }
+  );
 
-  it('Should move focus to the first popup child with return key from Menu bar',
+  it(
+    'Should move focus to the first popup child with return key from Menu bar',
     () => {
       domElements.listFirstItem.focus();
       domElements.listFirstItem.dispatchEvent(keydownReturn);
@@ -209,7 +226,8 @@ describe('Menu correctly responds to events', () => {
         expect(detail.state).toStrictEqual({ expanded: true });
         expect(target).toStrictEqual(domElements.listFirstItem);
       });
-    });
+    }
+  );
 
   it('Should close the submenu on right arrow key on a menu item with no submenu', () => {
     menuBar.setState({

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -16,7 +16,7 @@ const menubarMarkup = `
   <nav class="nav" aria-label="Menu Class Example">
     <ul class="menubar">
       <li>
-        <button target="first-popup" class="first-item">Fruit</button>
+        <button aria-controls="first-popup" class="first-item">Fruit</button>
         <ul id="first-popup" class="sublist1">
           <li><a class="sublist1-first-item" href="example.com">Apples</a></li>
           <li><a class="sublist1-second-item" href="example.com">Bananas</a></li>
@@ -26,7 +26,7 @@ const menubarMarkup = `
       <li><a class="second-item" href="example.com">Cake</a></li>
       <li>
         <svg><use href="my-icon"></use></svg>
-        <a target="second-popup" class="third-item" href="example.com">Vegetables</a>
+        <a aria-controls="second-popup" class="third-item" href="example.com">Vegetables</a>
         <div id="second-popup" class="not-a-list">
           <ul class="sublist2">
             <li><a class="sublist2-first-item" href="example.com">Carrots</a></li>

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -181,7 +181,7 @@ export default class MenuBar extends AriaComponent {
     // Initialize popups for nested lists.
     const { popups, subMenus } = this.menuBarItems.reduce((acc, controller) => {
       // Bail if there's no target attribute.
-      if (! controller.hasAttribute('target')) {
+      if (! controller.hasAttribute('aria-controls')) {
         return acc;
       }
 

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -125,7 +125,6 @@ it('Should not manage the target element\'s `hidden` attribute', () => {
   menuButton.show();
 });
 
-
 it('Should fire `stateChange` event on state change: hidden', () => {
   menuButton.hide();
   expect(menuButton.getState().expanded).toBe(false);
@@ -141,87 +140,107 @@ it('Should fire `stateChange` event on state change: hidden', () => {
 });
 
 describe('MenuButton correctly responds to events', () => {
-  it('Should close the menuButton when the ESC key is pressed',
+  it(
+    'Should close the menuButton when the ESC key is pressed',
     () => {
       menuButton.show();
       controller.focus();
       controller.dispatchEvent(keydownEsc);
       expect(menuButton.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should move focus to the first menu item with Return key from controller',
+  it(
+    'Should move focus to the first menu item with Return key from controller',
     () => {
       menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownReturn);
       expect(menuButton.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(domFirstChild);
-    });
+    }
+  );
 
-  it('Should move focus to the first menu item with Spacebar from controller',
+  it(
+    'Should move focus to the first menu item with Spacebar from controller',
     () => {
       menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownSpace);
       expect(menuButton.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(domFirstChild);
-    });
+    }
+  );
 
-  it('Should move focus to the first menu item with down arrow from controller',
+  it(
+    'Should move focus to the first menu item with down arrow from controller',
     () => {
       menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownDown);
       expect(menuButton.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(domFirstChild);
-    });
+    }
+  );
 
-  it('Should move focus to the last menu item with up arrow from controller',
+  it(
+    'Should move focus to the last menu item with up arrow from controller',
     () => {
       menuButton.hide();
       controller.focus();
       controller.dispatchEvent(keydownUp);
       expect(menuButton.getState().expanded).toBeTruthy();
       expect(document.activeElement).toEqual(domLastChild);
-    });
+    }
+  );
 
-  it('Should move focus to the first menu child on TAB from controller',
+  it(
+    'Should move focus to the first menu child on TAB from controller',
     () => {
       menuButton.show();
       controller.dispatchEvent(keydownTab);
       expect(document.activeElement).toEqual(domFirstChild);
-    });
+    }
+  );
 
-  it('Should close the menuButton and focus the controller when the ESC key is pressed',
+  it(
+    'Should close the menuButton and focus the controller when the ESC key is pressed',
     () => {
       menuButton.show();
       target.dispatchEvent(keydownEsc);
       expect(menuButton.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should close the menuButton when tabbing from the last child',
+  it(
+    'Should close the menuButton when tabbing from the last child',
     () => {
       menuButton.show();
       domLastChild.focus();
       target.dispatchEvent(keydownTab);
       expect(menuButton.getState().expanded).toBeFalsy();
-    });
+    }
+  );
 
-  it('Should focus the controller when tabbing back from the first child',
+  it(
+    'Should focus the controller when tabbing back from the first child',
     () => {
       menuButton.show();
       domFirstChild.focus();
       target.dispatchEvent(keydownShiftTab);
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should close the menuButton when an outside element it clicked',
+  it(
+    'Should close the menuButton when an outside element it clicked',
     () => {
       document.body.dispatchEvent(click);
       expect(menuButton.getState().expanded).toBeFalsy();
-    });
+    }
+  );
 });
 
 it('Should destroy the menuButton as expected', () => {

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -229,7 +229,7 @@ it('Should destroy the menuButton as expected', () => {
 
   expect(controller.getAttribute('aria-haspopup')).toBeNull();
   expect(controller.getAttribute('aria-expanded')).toBeNull();
-  expect(controller.getAttribute('aria-controls')).toBeNull();
+  expect(controller.getAttribute('aria-controls')).toEqual(target.id);
   expect(target.getAttribute('aria-hidden')).toBeNull();
   expect(target.getAttribute('hidden')).toBeNull();
 

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -14,7 +14,7 @@ const {
 } = events;
 
 const menuButtonMarkup = `
-  <button target="dropdown">Open</button>
+  <button aria-controls="dropdown">Open</button>
   <div class="wrapper" id="dropdown">
     <ul>
       <li><a class="first-child" href="example.com"></a></li>

--- a/src/MenuButton/README.md
+++ b/src/MenuButton/README.md
@@ -6,7 +6,7 @@ Class for setting up an interactive popup button to activate a target menu eleme
 ## Example
 
 ```html
-<button target="menu">Open</button>
+<button aria-controls="menu">Open</button>
 <div id="menu">
   <ul>
     <li><a href="example.com"></a></li>
@@ -31,8 +31,9 @@ MenuButton(controller = null, options = {});
 ```
 
 _**`controller`**_ `HTMLElement`  
-> The element used to activate the MenuButton target; required to have a `target`  
-attribute with a value matching the `id` attribute value of the target element.
+> The element used to activate the MenuButton target; required to have a  
+> `aria-controls` attribute with a value matching the `id` attribute value of the  
+> target element.
 
 _**`options`**_ `object`  
 > Configuration options.

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -12,7 +12,7 @@ const {
 } = events;
 
 const popupMarkup = `
-  <a target="dropdown" href="#dropdown" class="link">Open</a>
+  <a aria-controls="dropdown" href="#dropdown" class="link">Open</a>
   <div class="wrapper" id="dropdown">
     <ul>
       <li><a class="first-child" href="example.com"></a></li>
@@ -61,7 +61,6 @@ describe('Popup adds and manipulates DOM element attributes', () => {
   it('Should add the correct attributes to the popup controller', () => {
     expect(controller.getAttribute('aria-haspopup')).toEqual('true');
     expect(controller.getAttribute('aria-expanded')).toEqual('false');
-    expect(controller.getAttribute('aria-controls')).toEqual('dropdown');
 
     // Link controller should get button role.
     expect(controller.getAttribute('role')).toEqual('button');
@@ -218,7 +217,7 @@ describe('Popup destroy', () => {
     }
     expect(controller.getAttribute('aria-haspopup')).toBeNull();
     expect(controller.getAttribute('aria-expanded')).toBeNull();
-    expect(controller.getAttribute('aria-controls')).toBeNull();
+    expect(controller.getAttribute('aria-controls')).toEqual('dropdown');
     expect(controller.getAttribute('aria-owns')).toBeNull();
     expect(target.getAttribute('aria-hidden')).toBeNull();
     expect(target.getAttribute('hidden')).toBeNull();

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -146,20 +146,24 @@ describe('Popup correctly responds to events', () => {
     popup.show();
   });
 
-  it('Should close the popup when the ESC key is pressed',
+  it(
+    'Should close the popup when the ESC key is pressed',
     () => {
       controller.focus();
       controller.dispatchEvent(keydownEsc);
       expect(popup.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should move focus to the first popup child on TAB from controller',
+  it(
+    'Should move focus to the first popup child on TAB from controller',
     () => {
       controller.dispatchEvent(keydownTab);
       expect(document.activeElement)
         .toEqual(domFirstChild);
-    });
+    }
+  );
 
   it('Should update Popup state with keyboard', () => {
     // Toggle popup
@@ -172,39 +176,49 @@ describe('Popup correctly responds to events', () => {
   });
 
   // eslint-disable-next-line max-len
-  it('Should close the popup and focus the controller when the ESC key is pressed',
+  it(
+    'Should close the popup and focus the controller when the ESC key is pressed',
     () => {
       target.dispatchEvent(keydownEsc);
       expect(popup.getState().expanded).toBeFalsy();
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should close the popup when tabbing from the last child',
+  it(
+    'Should close the popup when tabbing from the last child',
     () => {
       domLastChild.focus();
       target.dispatchEvent(keydownTab);
       expect(popup.getState().expanded).toBeFalsy();
-    });
+    }
+  );
 
-  it('Should not close the popup when tabbing back from the last child',
+  it(
+    'Should not close the popup when tabbing back from the last child',
     () => {
       domLastChild.focus();
       target.dispatchEvent(keydownShiftTab);
       expect(popup.getState().expanded).toBeTruthy();
-    });
+    }
+  );
 
-  it('Should focus the controller when tabbing back from the first child',
+  it(
+    'Should focus the controller when tabbing back from the first child',
     () => {
       domFirstChild.focus();
       target.dispatchEvent(keydownShiftTab);
       expect(document.activeElement).toEqual(controller);
-    });
+    }
+  );
 
-  it('Should close the popup when an outside element it clicked',
+  it(
+    'Should close the popup when an outside element it clicked',
     () => {
       document.body.dispatchEvent(click);
       expect(popup.getState().expanded).toBeFalsy();
-    });
+    }
+  );
 });
 
 describe('Popup destroy', () => {

--- a/src/Popup/README.md
+++ b/src/Popup/README.md
@@ -6,7 +6,7 @@ Class for setting up an interactive popup button to activate a target element.
 ## Example
 
 ```html
-<button target="popup">Open</button>
+<button aria-controls="popup">Open</button>
 <div id="popup">
   <ul>
     <li><a href="example.com"></a></li>
@@ -31,7 +31,7 @@ Popup(controller = null, options = {});
 ```
 
 _**`controller`**_ `HTMLElement`  
-> The element used to activate the Popup target; required to have a `target`  
+> The element used to activate the Popup target; required to have a `aria-controls`  
 attribute with a value matching the `id` attribute value of the target element.
 
 _**`options`**_ `object`  

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -104,7 +104,6 @@ export default class Popup extends AriaComponent {
     // Add controller attributes
     this.controller.setAttribute('aria-haspopup', this.type);
     this.controller.setAttribute('aria-expanded', 'false');
-    this.controller.setAttribute('aria-controls', this.target.id);
     setUniqueId(this.controller);
 
     /**
@@ -330,7 +329,6 @@ export default class Popup extends AriaComponent {
     // Remove controller attributes.
     this.controller.removeAttribute('aria-haspopup');
     this.controller.removeAttribute('aria-expanded');
-    this.controller.removeAttribute('aria-controls');
     this.controller.removeAttribute('aria-owns');
 
     // Remove role and tabindex added to a link controller.

--- a/src/Tablist/README.md
+++ b/src/Tablist/README.md
@@ -8,9 +8,9 @@ at a time.
 
 ```html
 <ul class="tabs">
-  <li><a href="#first-panel"></a></li>
-  <li><a href="#second-panel"></a></li>
-  <li><a href="#third-panel"></a></li>
+  <li><a aria-controls="first-panel" href="#first-panel"></a></li>
+  <li><a aria-controls="second-panel" href="#second-panel"></a></li>
+  <li><a aria-controls="third-panel" href="#third-panel"></a></li>
 </ul>
 <div id="first-panel" class="panel">
   <h3>The First Panel Title</h3>
@@ -51,8 +51,8 @@ Tablist(tabsListElement = null);
 ```
 
 _**`tabsListElement`**_ `HTMLUListElement`  
-> The list element containing tab links; each link's `href` is a fragment  
-identifier linking to the associated panel.
+> The list element containing tab links; each link must contain an \`aria-controls\`  
+> attribute referencing the ID of the associated tabPanel.
 
 ## API
 

--- a/src/Tablist/Tablist.test.js
+++ b/src/Tablist/Tablist.test.js
@@ -15,9 +15,9 @@ const {
 
 const tablistMarkup = `
   <ul class="tablist">
-    <li><a href="#first-panel"></a></li>
-    <li><a href="#second-panel"></a></li>
-    <li><a href="#third-panel"></a></li>
+    <li><a aria-controls="first-panel" href="#first-panel"></a></li>
+    <li><a aria-controls="second-panel" href="#second-panel"></a></li>
+    <li><a aria-controls="third-panel" href="#third-panel"></a></li>
   </ul>
   <div id="first-panel" class="panel">
     <h1>The Article Title</h1>
@@ -60,9 +60,9 @@ const panels = document.querySelectorAll('.panel');
 let tablist = {};
 
 // Cached selectors.
-const firstTab = document.querySelector('a[href="#first-panel"]');
-const secondTab = document.querySelector('a[href="#second-panel"]');
-const thirdTab = document.querySelector('a[href="#third-panel"]');
+const firstTab = document.querySelector('[aria-controls="first-panel"]');
+const secondTab = document.querySelector('[aria-controls="second-panel"]');
+const thirdTab = document.querySelector('[aria-controls="third-panel"]');
 const firstPanel = document.querySelector('#first-panel');
 const secondPanel = document.querySelector('#second-panel');
 const thirdPanel = document.querySelector('#third-panel');
@@ -115,7 +115,6 @@ describe('Tablist with default configuration', () => {
           expect(tab.getAttribute('aria-selected')).toEqual((0 === index) ? 'true' : null);
           expect(tab.getAttribute('tabindex')).toEqual((0 === index) ? null : '-1');
           expect(tab.id).not.toBeNull();
-          expect(tabLinks[index].getAttribute('aria-controls')).toEqual(panels[index].id);
         });
 
         Array.from(panels).forEach((panel, index) => {
@@ -212,7 +211,7 @@ describe('Tablist with default configuration', () => {
         expect(tab.getAttribute('role')).toBeNull();
         expect(tab.getAttribute('aria-selected')).toBeNull();
         expect(tab.getAttribute('tabindex')).toBeNull();
-        expect(tabLinks[index].getAttribute('aria-controls')).toBeNull();
+        expect(tabLinks[index].getAttribute('aria-controls')).toEqual(panels[index].id);
       });
 
       Array.from(panels).forEach((panel) => {

--- a/src/Tablist/Tablist.test.js
+++ b/src/Tablist/Tablist.test.js
@@ -99,7 +99,8 @@ describe('Tablist with default configuration', () => {
       });
     });
 
-    it('Should add the correct attributes and overlay element',
+    it(
+      'Should add the correct attributes and overlay element',
       () => {
         expect(tabs.getAttribute('role')).toEqual('tablist');
 
@@ -129,7 +130,8 @@ describe('Tablist with default configuration', () => {
           expect(panel.getAttribute('aria-labelledby')).not.toBeNull();
           expect(panel.id).not.toBeNull();
         });
-      });
+      }
+    );
   });
 
   describe('Tablist methods work as expected', () => {

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -69,7 +69,7 @@ export default class Tablist extends AriaComponent {
      */
     const { tabLinks, panels } = Array.from(this.tabs.children)
       .reduce((acc, child) => {
-        const tabLink = child.querySelector('a[href]');
+        const tabLink = child.querySelector('a[aria-controls]');
 
         if (null === tabLink) {
           return acc;
@@ -142,8 +142,6 @@ export default class Tablist extends AriaComponent {
         // Set the first tab as selected by default.
         tab.setAttribute('aria-selected', 'true');
       }
-
-      tab.setAttribute('aria-controls', this.panels[index].id);
     });
 
     // Add event listeners.
@@ -392,7 +390,6 @@ export default class Tablist extends AriaComponent {
       tab.removeAttribute('role');
       tab.removeAttribute('aria-selected');
       tab.removeAttribute('tabindex');
-      tab.removeAttribute('aria-controls');
 
       tab.removeEventListener('click', this.tabsHandleClick);
       tab.removeEventListener('keydown', this.tabsHandleKeydown);

--- a/src/lib/getFirstAndLastItems.test.js
+++ b/src/lib/getFirstAndLastItems.test.js
@@ -12,15 +12,18 @@ document.body.innerHTML = `
 `;
 
 describe('Should get the first and last items', () => {
-  it('From an Array',
+  it(
+    'From an Array',
     () => {
       const testArray = ['first', 'hello', 'world', 'last'];
       const firstLast = getFirstAndLastItems(testArray);
 
       expect(firstLast).toEqual(['first', 'last']);
-    });
+    }
+  );
 
-  it('From a NodeList',
+  it(
+    'From a NodeList',
     () => {
       const nodeList = document.querySelectorAll('div');
       const firstLast = getFirstAndLastItems(nodeList);
@@ -29,17 +32,21 @@ describe('Should get the first and last items', () => {
       const domLast = document.querySelector('.last');
 
       expect(firstLast).toEqual([domFirst, domLast]);
-    });
+    }
+  );
 
-  it('From a single-item Array',
+  it(
+    'From a single-item Array',
     () => {
       const testArray = ['only'];
       const firstLast = getFirstAndLastItems(testArray);
 
       expect(firstLast).toEqual(['only', 'only']);
-    });
+    }
+  );
 
-  it('From a single-item NodeList',
+  it(
+    'From a single-item NodeList',
     () => {
       const nodeList = document.querySelectorAll('.first');
       const firstLast = getFirstAndLastItems(nodeList);
@@ -47,5 +54,6 @@ describe('Should get the first and last items', () => {
       const expected = nodeList[0];
 
       expect(firstLast).toEqual([expected, expected]);
-    });
+    }
+  );
 });

--- a/src/lib/isInstanceOf.test.js
+++ b/src/lib/isInstanceOf.test.js
@@ -27,33 +27,45 @@ const menu = new Menu(list);
 const helloWorld = { hello: 'world' };
 
 describe('Should return whether a given object is an instance of a class', () => {
-  it('Should be a Popup instance',
+  it(
+    'Should be a Popup instance',
     () => {
       expect(isInstanceOf('Popup', popup)).toBeTruthy();
-    });
+    }
+  );
 
-  it('Should be case-insensitive',
+  it(
+    'Should be case-insensitive',
     () => {
       expect(isInstanceOf('pOpUp', popup)).toBeTruthy();
-    });
+    }
+  );
 
-  it('Should be a Menu instance',
+  it(
+    'Should be a Menu instance',
     () => {
       expect(isInstanceOf('menu', menu)).toBeTruthy();
-    });
+    }
+  );
 
-  it('Should return false for a non-existant element',
+  it(
+    'Should return false for a non-existant element',
     () => {
       expect(isInstanceOf('Menu', target.unknown)).toBeFalsy();
-    });
+    }
+  );
 
-  it('Should return false for non-aria-component object',
+  it(
+    'Should return false for non-aria-component object',
     () => {
       expect(isInstanceOf('Dialog', helloWorld)).toBeFalsy();
-    });
+    }
+  );
 
-  it('Should return false for nonsensical parameter values',
+  it(
+    'Should return false for nonsensical parameter values',
     () => {
       expect(isInstanceOf(4, 'whatever')).toBeFalsy();
-    });
+    }
+  );
 });

--- a/src/lib/isInstanceOf.test.js
+++ b/src/lib/isInstanceOf.test.js
@@ -5,7 +5,7 @@ import isInstanceOf from './isInstanceOf';
 
 // Set up our document body
 document.body.innerHTML = `
-  <button target="dropdown">Open</button>
+  <button aria-controls="dropdown">Open</button>
   <div class="wrapper" id="dropdown">
     <ul class="menu">
       <li><a href="example.com"></a></li>


### PR DESCRIPTION
Previously supported the non-standard `target` attribute.