### PR TITLE
Warn when Menu components are used for website navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Exports `isInstanceOf` helper function (#52)
 - Allows authors to disable the use of the hidden attribute in Dialog, Disclosure, and Popup state changes via the `useHiddenAttribute` option. (#61)
 - `instance.on()` and `instance.off()` methods for subscribing to events (#67)
+- Menu, MenuBar, and MenuButton will log a warning if used for website navigation (#68)
 
 **Fixed**
 

--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -128,6 +128,7 @@ export default class AriaComponent {
     this.dispatchEventDestroy = this.dispatchEventDestroy.bind(this);
     this.on = this.on.bind(this);
     this.off = this.off.bind(this);
+    this.warnMenu = this.warnMenu.bind(this);
   }
 
   /**
@@ -285,5 +286,17 @@ export default class AriaComponent {
    */
   getState() {
     return this.state;
+  }
+
+  /**
+   * Menu-specific warning helper.
+   */
+  warnMenu() {
+    /* eslint-disable no-console, max-len */
+    console.group(`[aria-components]: ${this.stringDescription}`);
+    console.warn('This component is only appropriate for application-like menus and should not be used for a website navigation.');
+    console.info('Pass `__is_application_menu: true` to quiet this warning.');
+    console.groupEnd();
+    /* eslint-enable */
   }
 }

--- a/src/Menu/Menu.test.js
+++ b/src/Menu/Menu.test.js
@@ -79,6 +79,7 @@ let menu = new Menu(
   {
     itemMatches: ':not(.exclude)',
     _stateDispatchesOnly: true,
+    __is_application_menu: true,
   }
 );
 menu.on('stateChange', onStateChange);
@@ -240,6 +241,7 @@ describe('Menu instatiates submenus as Disclosures', () => {
       {
         itemMatches: ':not(.exclude)',
         collapse: true,
+        __is_application_menu: true,
       }
     );
   });

--- a/src/Menu/README.md
+++ b/src/Menu/README.md
@@ -3,6 +3,13 @@ Menu
 
 Class to set up an vertically oriented interactive Menu element.
 
+```
+This component is only appropriate for application-like
+menus and should not be used for a website navigation.
+
+Pass `__is_application_menu: true` to suppress the warning.
+```
+
 ## Example
 
 ```html
@@ -57,6 +64,9 @@ _**`itemMatches`**_`= 'a,button'`
 > 
 > This can also be used to exclude items that would otherwise be given a  
 > "menuitem" role; e.g., `':not(.hidden)'`.
+
+_**`__is_application_menu`**_`= false`  
+> Quiet console warnings.
 
 ## API
 

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -71,10 +71,22 @@ export default class Menu extends AriaComponent {
        * @type {string}
        */
       itemMatches: 'a,button',
+
+      /**
+       * This is an application menu.
+       *
+       * @type {Boolean}
+       */
+      __is_application_menu: false,
     };
 
     // Merge remaining options with defaults and save all as instance properties.
     Object.assign(this, defaultOptions, options);
+
+    // Log a warning to alert about menu anti-pattern.
+    if (! this.__is_application_menu) { // eslint-disable-line no-underscore-dangle
+      this.warnMenu();
+    }
 
     // Bind class methods
     this.listHandleKeydown = this.listHandleKeydown.bind(this);
@@ -187,6 +199,8 @@ export default class Menu extends AriaComponent {
           {
             itemMatches: this.itemMatches,
             _stateDispatchesOnly: true,
+            // Quiet duplicated warnings.
+            __is_application_menu: true,
           }
         );
 

--- a/src/MenuBar/MenuBar.test.js
+++ b/src/MenuBar/MenuBar.test.js
@@ -76,7 +76,14 @@ const { list } = domElements;
 // The `init` event is not trackable via on/off.
 list.addEventListener('init', onInit);
 
-const menuBar = new MenuBar(list, { itemMatches: ':not(.exclude)' });
+const menuBar = new MenuBar(
+  list,
+  {
+    itemMatches: ':not(.exclude)',
+    __is_application_menu: true,
+  }
+);
+
 menuBar.on('stateChange', onStateChange);
 menuBar.on('destroy', onDestroy);
 

--- a/src/MenuBar/README.md
+++ b/src/MenuBar/README.md
@@ -4,6 +4,13 @@ MenuBar
 Class for managing a visually persistent (horizontally-oriented) menubar, with 
 each submenu instantiated as a Disclosure.
 
+```
+This component is only appropriate for application-like
+menus and should not be used for a website navigation.
+
+Pass `__is_application_menu: true` to suppress the warning.
+```
+
 ## Example
 
 ```html
@@ -55,6 +62,9 @@ _**`itemMatches`**_`= 'a,button'`
 > 
 > This can also be used to exclude items that would otherwise be given a  
 > "menuitem" role; e.g., `':not(.hidden)'`.
+
+_**`__is_application_menu`**_`= false`  
+> Quiet console warnings.
 
 ## API
 

--- a/src/MenuBar/index.js
+++ b/src/MenuBar/index.js
@@ -69,10 +69,22 @@ export default class MenuBar extends AriaComponent {
        * @type {string}
        */
       itemMatches: 'a,button',
+
+      /**
+       * This is an application menu.
+       *
+       * @type {Boolean}
+       */
+      __is_application_menu: false,
     };
 
     // Merge remaining options with defaults and save all as instance properties.
     Object.assign(this, defaultOptions, options);
+
+    // Log a warning to alert about menu anti-pattern.
+    if (! this.__is_application_menu) { // eslint-disable-line no-underscore-dangle
+      this.warnMenu();
+    }
 
     // Bind class methods.
     this.menubarHandleKeydown = this.menubarHandleKeydown.bind(this);
@@ -217,6 +229,8 @@ export default class MenuBar extends AriaComponent {
         {
           itemMatches: this.itemMatches,
           _stateDispatchesOnly: true,
+          // Quiet duplicated warnings.
+          __is_application_menu: true,
         }
       );
       target.addEventListener('keydown', this.menuItemHandleKeydown);

--- a/src/MenuButton/MenuButton.test.js
+++ b/src/MenuButton/MenuButton.test.js
@@ -43,7 +43,15 @@ const onDestroy = jest.fn();
 // The `init` event is not trackable via on/off.
 controller.addEventListener('init', onInit);
 
-const menuButton = new MenuButton(controller, { list, useHiddenAttribute: false });
+const menuButton = new MenuButton(
+  controller,
+  {
+    list,
+    useHiddenAttribute: false,
+    __is_application_menu: true,
+  }
+);
+
 menuButton.on('stateChange', onStateChange);
 menuButton.on('destroy', onDestroy);
 

--- a/src/MenuButton/README.md
+++ b/src/MenuButton/README.md
@@ -3,6 +3,13 @@ MenuButton
 
 Class for setting up an interactive popup button to activate a target menu element.
 
+```
+This component is only appropriate for application-like
+menus and should not be used for a website navigation.
+
+Pass `__is_application_menu: true` to suppress the warning.
+```
+
 ## Example
 
 ```html
@@ -49,6 +56,9 @@ _**`list`**_`= null`
 > Use this option if neither of the following should be used as the Menu list:  
 > 1. The target element, if it is an instance of `HTMLUListElement`
 > 2. The value returned by `target.querySelector('ul')`
+
+_**`__is_application_menu`**_`= false`  
+> Quiet console warnings.
 
 ## API
 

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -39,10 +39,22 @@ export default class MenuButton extends Popup {
        * @type {HTMLUListElement}
        */
       list: null,
+
+      /**
+       * This is an application menu.
+       *
+       * @type {Boolean}
+       */
+      __is_application_menu: false,
     };
 
     // Merge remaining options with defaults and save all as instance properties.
     Object.assign(this, defaultOptions, options);
+
+    // Log a warning to alert about menu anti-pattern.
+    if (! this.__is_application_menu) { // eslint-disable-line no-underscore-dangle
+      this.warnMenu();
+    }
 
     // Bind class methods.
     this.controllerHandleKeydown = this.controllerHandleKeydown.bind(this);
@@ -64,6 +76,13 @@ export default class MenuButton extends Popup {
      */
     super.setSelfReference(this.controller, this.target);
 
+    // Inner menu options.
+    const menuOptions = {
+      _stateDispatchesOnly: true,
+      // Quiet duplicated warnings.
+      __is_application_menu: true,
+    };
+
     /**
      * The MenuButton is a Popup to present a Menu. The element used as the Menu
      * is determined by the following "logic":
@@ -74,13 +93,13 @@ export default class MenuButton extends Popup {
      * @type {Menu}
      */
     if (null != this.list && 'UL' === this.list.nodeName) {
-      this.menu = new Menu(this.list, { _stateDispatchesOnly: true });
+      this.menu = new Menu(this.list, menuOptions);
     } else if ('UL' === this.target.nodeName) {
       // Fallback to the target if it's a UL.
-      this.menu = new Menu(this.target, { _stateDispatchesOnly: true });
+      this.menu = new Menu(this.target, menuOptions);
     } else {
       const list = this.target.querySelector('ul');
-      this.menu = new Menu(list, { _stateDispatchesOnly: true });
+      this.menu = new Menu(list, menuOptions);
     }
 
     // Additional event listener(s).

--- a/src/lib/isInstanceOf.test.js
+++ b/src/lib/isInstanceOf.test.js
@@ -22,7 +22,7 @@ const target = document.querySelector('.wrapper');
 const list = document.querySelector('.menu');
 
 const popup = new Popup(controller);
-const menu = new Menu(list);
+const menu = new Menu(list, { __is_application_menu: true });
 
 const helloWorld = { hello: 'world' };
 


### PR DESCRIPTION
This is a stop-gap to give more time to decide to remove them outright.