### PR TITLE
Get component element pair

### DIFF
--- a/src/AriaComponent.js
+++ b/src/AriaComponent.js
@@ -3,59 +3,6 @@
  */
 export default class AriaComponent {
   /**
-   * Get the target element based on the controller's `aria-controls` attribute.
-   *
-   * @param  {HTMLElement} controller The component's controlling element.
-   * @return {HTMLElement|null}
-   */
-  static getTargetElement(controller) {
-    if (! controller.hasAttribute('aria-controls')) {
-      AriaComponent.configurationError(
-        // eslint-disable-next-line max-len
-        'The component element is missing the required \'aria-controls\' attribute'
-      );
-    }
-
-    const targetId = controller.getAttribute('aria-controls');
-    const target = document.getElementById(targetId);
-
-    if (null === target) {
-      AriaComponent.configurationError(
-        `A target element with ID of '${targetId}' is not found`
-      );
-    }
-
-    return target;
-  }
-
-  /**
-   * Get the controlling element based on its `target` attribute matching the
-   * target element's ID attribute.
-   *
-   * @param  {HTMLElement} controller The component's controlling element.
-   * @return {HTMLElement|null}
-   */
-  static getControllingElement(target) {
-    if (! target.hasAttribute('id')) {
-      AriaComponent.configurationError(
-        'The target element is missing the required \'id\' attribute'
-      );
-    }
-
-    const targetId = target.id;
-    const controller = document.querySelector(`[aria-controls="${targetId}"]`);
-
-    if (null === controller) {
-      AriaComponent.configurationError(
-        // eslint-disable-next-line max-len
-        `A controlling element with \`aria-controls\` attribute of '${targetId}' is not found`
-      );
-    }
-
-    return controller;
-  }
-
-  /**
    * Throw a confguration error.
    *
    * @param {string} message The error message.

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,4 +1,5 @@
 import AriaComponent from '../AriaComponent';
+import getElementPair from '../lib/getElementPair';
 import interactiveChildren from '../lib/interactiveChildren';
 import keyCodes from '../lib/keyCodes';
 import getFirstAndLastItems from '../lib/getFirstAndLastItems';
@@ -14,11 +15,11 @@ export default class Dialog extends AriaComponent {
    * Create a Dialog.
    * @constructor
    *
-   * @param {HTMLElement} target  The dialog element.
+   * @param {HTMLElement} element The dialog element.
    * @param {object}      options The options object.
    */
-  constructor(target, options = {}) {
-    super(target);
+  constructor(element, options = {}) {
+    super(element);
 
     /**
      * The string description for this object.
@@ -26,8 +27,11 @@ export default class Dialog extends AriaComponent {
      * @type {string}
      */
     this[Symbol.toStringTag] = 'Dialog';
+
+    // Get the component elements.
+    const { controller, target } = getElementPair(element);
+    this.controller = controller;
     this.target = target;
-    this.controller = super.constructor.getControllingElement(target);
 
     /**
      * Options shape.

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -1,4 +1,5 @@
 import AriaComponent from '../AriaComponent';
+import getElementPair from '../lib/getElementPair';
 import keyCodes from '../lib/keyCodes';
 import interactiveChildren from '../lib/interactiveChildren';
 import { tabIndexDeny, tabIndexAllow } from '../lib/rovingTabIndex';
@@ -15,11 +16,11 @@ export default class Disclosure extends AriaComponent {
    * Create a Disclosure.
    * @constructor
    *
-   * @param {HTMLElement} controller The activating element.
-   * @param {object}      options    The options object.
+   * @param {HTMLElement} element The activating element.
+   * @param {object}      options The options object.
    */
-  constructor(controller, options = {}) {
-    super(controller);
+  constructor(element, options = {}) {
+    super(element);
 
     /**
      * The string description for this object.
@@ -28,8 +29,10 @@ export default class Disclosure extends AriaComponent {
      */
     this[Symbol.toStringTag] = 'Disclosure';
 
+    // Get the component elements.
+    const { controller, target } = getElementPair(element);
     this.controller = controller;
-    this.target = super.constructor.getTargetElement(controller);
+    this.target = target;
 
     /**
      * Options shape.

--- a/src/Listbox/index.js
+++ b/src/Listbox/index.js
@@ -1,4 +1,5 @@
 import Popup from '../Popup';
+import getElementPair from '../lib/getElementPair';
 import { setUniqueId } from '../lib/uniqueId';
 import keyCodes from '../lib/keyCodes';
 import Search from '../lib/Search';
@@ -14,12 +15,12 @@ export default class ListBox extends Popup {
    * Create a ListBox.
    * @constructor
    *
-   * @param {HTMLElement} controller The activating element.
-   * @param {object}      options    The options object.
+   * @param {HTMLElement} lement  The activating element.
+   * @param {object}      options The options object.
    */
-  constructor(controller, options = {}) {
+  constructor(element, options = {}) {
     // Pass in the `listbox` type.
-    super(controller, { ...options, type: 'listbox' });
+    super(element, { ...options, type: 'listbox' });
 
     /**
      * The string description for this object.
@@ -28,8 +29,10 @@ export default class ListBox extends Popup {
      */
     this[Symbol.toStringTag] = 'Listbox';
 
+    // Get the component elements.
+    const { controller, target } = getElementPair(element);
     this.controller = controller;
-    this.target = super.constructor.getTargetElement(controller);
+    this.target = target;
 
     // Merge options as instance properties.
     Object.assign(this, options);

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -1,4 +1,5 @@
 import AriaComponent from '../AriaComponent';
+import getElementPair from '../lib/getElementPair';
 import keyCodes from '../lib/keyCodes';
 import interactiveChildren from '../lib/interactiveChildren';
 import { tabIndexDeny, tabIndexAllow } from '../lib/rovingTabIndex';
@@ -14,11 +15,11 @@ export default class Popup extends AriaComponent {
    * Create a MenuBar.
    * @constructor
    *
-   * @param {HTMLElement} controller The activating element.
-   * @param {object}      options    The options object.
+   * @param {HTMLElement} element The activating element.
+   * @param {object}      options The options object.
    */
-  constructor(controller, options = {}) {
-    super(controller);
+  constructor(element, options = {}) {
+    super(element);
 
     /**
      * The string description for this object.
@@ -27,8 +28,10 @@ export default class Popup extends AriaComponent {
      */
     super[Symbol.toStringTag] = 'Popup';
 
+    // Get the component elements.
+    const { controller, target } = getElementPair(element);
     this.controller = controller;
-    this.target = super.constructor.getTargetElement(controller);
+    this.target = target;
 
     /**
      * Component configuration options.

--- a/src/lib/getElementPair.js
+++ b/src/lib/getElementPair.js
@@ -1,0 +1,45 @@
+/**
+ * Get the controller and target elements based on the given element's attributes.
+ *
+ * @param  {HTMLElement} element Either the controller or target element.
+ * @return {object} The controller and target elements.
+ */
+const getElementPair = (element) => {
+  let controller = null;
+  let target = null;
+
+
+  // Use the aria-controls attribute value to find the target element.
+  if (element.hasAttribute('aria-controls')) {
+    const elementControls = element.getAttribute('aria-controls');
+    target = document.getElementById(elementControls);
+
+    if (target === null) {
+      throw new Error(`Configuration error: A target element with \`id="${elementControls}"\` is not found`);
+    } else {
+      return {
+        controller: element,
+        target,
+      };
+    }
+  }
+
+  // Find the controlling element based on the target element's id attribute.
+  if (element.hasAttribute('id')) {
+    const elementId = element.id;
+    controller = document.querySelector(`[aria-controls="${elementId}"]`);
+
+    if (controller === null) {
+      throw new Error(`Configuration error: A controlling element with \`aria-controls="${elementId}"\` is not found`);
+    } else {
+      return {
+        controller,
+        target: element,
+      };
+    }
+  }
+
+  return false;
+};
+
+export default getElementPair;

--- a/src/lib/getElementPair.js
+++ b/src/lib/getElementPair.js
@@ -39,7 +39,7 @@ const getElementPair = (element) => {
     }
   }
 
-  return false;
+  throw new Error(`Configuration error: The element is missing the required attributes`);
 };
 
 export default getElementPair;

--- a/src/lib/getElementPair.test.js
+++ b/src/lib/getElementPair.test.js
@@ -1,0 +1,43 @@
+import getElementPair from './getElementPair';
+
+describe('Collects interactive child elements', () => {
+  // Set up our document body
+  document.body.innerHTML = `
+    <button class="with-pair" aria-controls="existing-id">Correct<button>
+    <div id="existing-id"></div>
+    <button class="no-target" aria-controls="non-existant-id">Correct<button>
+    <div class="no-controller" id="no-matching-controller"></div>
+  `;
+
+  const validController = document.querySelector('.with-pair');
+  const validTarget = document.getElementById('existing-id');
+
+  const hasNoTarget = document.querySelector('.no-target');
+  const hasNoController = document.querySelector('.no-controller');
+
+  it('Given a valid controller, should return a matching pair of elements', () => {
+    const actual = getElementPair(validController);
+
+    expect(actual).toEqual({
+      controller: validController,
+      target: validTarget,
+    });
+  });
+
+  it('Given a valid target, should return a matching pair of elements', () => {
+    const actual = getElementPair(validTarget);
+
+    expect(actual).toEqual({
+      controller: validController,
+      target: validTarget,
+    });
+  });
+
+  it('Invalid: Controller has no target', () => {
+    expect(() => getElementPair(hasNoTarget)).toThrow();
+  });
+
+  it('Invalid: Target has no controller', () => {
+    expect(() => getElementPair(hasNoController)).toThrow();
+  });
+});

--- a/src/lib/getElementPair.test.js
+++ b/src/lib/getElementPair.test.js
@@ -7,6 +7,7 @@ describe('Collects interactive child elements', () => {
     <div id="existing-id"></div>
     <button class="no-target" aria-controls="non-existant-id">Correct<button>
     <div class="no-controller" id="no-matching-controller"></div>
+    <div class="no-attributes"></div>
   `;
 
   const validController = document.querySelector('.with-pair');
@@ -14,6 +15,7 @@ describe('Collects interactive child elements', () => {
 
   const hasNoTarget = document.querySelector('.no-target');
   const hasNoController = document.querySelector('.no-controller');
+  const hasNoAttributes = document.querySelector('.no-attributes');
 
   it('Given a valid controller, should return a matching pair of elements', () => {
     const actual = getElementPair(validController);
@@ -33,11 +35,15 @@ describe('Collects interactive child elements', () => {
     });
   });
 
-  it('Invalid: Controller has no target', () => {
+  it('Error: Controller has no target', () => {
     expect(() => getElementPair(hasNoTarget)).toThrow();
   });
 
-  it('Invalid: Target has no controller', () => {
+  it('Error: Target has no controller', () => {
     expect(() => getElementPair(hasNoController)).toThrow();
+  });
+
+  it('Error: Element has no required attributes', () => {
+    expect(() => getElementPair(hasNoAttributes)).toThrow();
   });
 });


### PR DESCRIPTION
Moves class methods that don't apply globally to a utility function that can be imported where a target and controller element pair is required.