### PR TITLE
Feature/disclosure options

### DIFF
--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -6,6 +6,9 @@ const {
   click,
   keydownReturn,
   keydownSpace,
+  keydownEsc,
+  keydownTab,
+  keydownShiftTab,
 } = events;
 
 const disclosureMarkup = `
@@ -14,7 +17,9 @@ const disclosureMarkup = `
       <button aria-controls="answer">What is Lorem Ipsum?</button>
     </dt>
     <dd id="answer">
+      <a class="first-child" href="example.com"></a>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      <a class="last-child" href="example.com"></a>
     </dd>
   </dl>
 `;
@@ -24,6 +29,9 @@ document.body.innerHTML = disclosureMarkup;
 
 const controller = document.querySelector('button');
 const target = document.querySelector('#answer');
+
+const domFirstChild = document.querySelector('.first-child');
+const domLastChild = document.querySelector('.last-child');
 
 // Mock functions.
 const onStateChange = jest.fn();
@@ -54,6 +62,9 @@ describe('Disclosure with default configuration', () => {
 
       expect(controller.disclosure).toBeInstanceOf(Disclosure);
       expect(target.disclosure).toBeInstanceOf(Disclosure);
+
+      expect(disclosure.firstInteractiveChild).toEqual(domFirstChild);
+      expect(disclosure.lastInteractiveChild).toEqual(domLastChild);
 
       expect(onInit).toHaveBeenCalledTimes(1);
       return Promise.resolve().then(() => {
@@ -221,4 +232,94 @@ describe('Disclosure supresses firing the `init` event', () => {
   disclosure.destroy();
   expect(beCalled).toHaveBeenCalledTimes(1);
   expect(shouldNotBeCalled).toHaveBeenCalledTimes(0);
+});
+
+describe('Disclosure with autoClose: true', () => {
+  beforeEach(() => {
+    if (disclosure instanceof Disclosure) {
+      disclosure.destroy();
+    }
+
+    disclosure = new Disclosure(controller, { autoClose: true });
+  });
+
+  describe('Disclosure correctly responds to events', () => {
+    // Ensure the Disclosure is open before all tests.
+    beforeEach(() => {
+      disclosure.open();
+    });
+
+    it(
+      'Should close the Disclosure when the ESC key is pressed',
+      () => {
+        controller.focus();
+        controller.dispatchEvent(keydownEsc);
+        expect(disclosure.getState().expanded).toBeFalsy();
+        expect(document.activeElement).toEqual(controller);
+      }
+    );
+
+    it(
+      'Should move focus to the first Disclosure child on TAB from controller',
+      () => {
+        controller.dispatchEvent(keydownTab);
+        expect(document.activeElement)
+          .toEqual(domFirstChild);
+      }
+    );
+
+    it('Should update Disclosure state with keyboard', () => {
+      // Toggle Disclosure
+      controller.dispatchEvent(keydownSpace);
+      expect(disclosure.getState().expanded).toBeFalsy();
+
+      // Toggle Disclosure
+      controller.dispatchEvent(keydownReturn);
+      expect(disclosure.getState().expanded).toBeTruthy();
+    });
+
+    it(
+      'Should close the Disclosure and focus the controller when the ESC key is pressed',
+      () => {
+        target.dispatchEvent(keydownEsc);
+        expect(disclosure.getState().expanded).toBeFalsy();
+        expect(document.activeElement).toEqual(controller);
+      }
+    );
+
+    it(
+      'Should close the Disclosure when tabbing from the last child',
+      () => {
+        domLastChild.focus();
+        target.dispatchEvent(keydownTab);
+        expect(disclosure.getState().expanded).toBeFalsy();
+      }
+    );
+
+    it(
+      'Should not close the Disclosure when tabbing back from the last child',
+      () => {
+        domLastChild.focus();
+        target.dispatchEvent(keydownShiftTab);
+        expect(disclosure.getState().expanded).toBeTruthy();
+      }
+    );
+
+    it(
+      'Should focus the controller when tabbing back from the first child',
+      () => {
+        domFirstChild.focus();
+        target.dispatchEvent(keydownShiftTab);
+        expect(document.activeElement).toEqual(controller);
+      }
+    );
+
+    it.skip(
+      'Should close the Disclosure when an outside element it clicked',
+      () => {
+        document.body.dispatchEvent(click);
+        expect(disclosure.getState().expanded).toBeFalsy();
+      }
+    );
+  });
 });

--- a/src/Disclosure/README.md
+++ b/src/Disclosure/README.md
@@ -45,6 +45,9 @@ _**`loadOpen`**_`= false`
 _**`allowOutsideClick`**_`= true`  
 > Whether to keep the Disclosure open when clicking outside of it.
 
+_**`autoClose`**_`= false`  
+> Automatically close the Disclosure when its contents lose focus.
+
 ## API
 
 ### Instance Methods

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -48,7 +48,9 @@ export default class Menu extends AriaComponent {
     // Merge options.
     const {
       _stateDispatchesOnly,
+      autoClose,
     } = {
+      autoClose: false,
       _stateDispatchesOnly: false,
 
       ...options,
@@ -60,6 +62,13 @@ export default class Menu extends AriaComponent {
      * @type {Boolean}
      */
     this._stateDispatchesOnly = _stateDispatchesOnly;
+
+    /**
+     * Close submenu Disclosures when they lose focus.
+     *
+     * @type {Boolean}
+     */
+    this.autoClose = autoClose;
 
     // Bind class methods
     this.destroy = this.destroy.bind(this);
@@ -90,7 +99,13 @@ export default class Menu extends AriaComponent {
       }
 
       if (undefined !== itemLink && itemLink.hasAttribute('aria-controls')) {
-        const disclosure = new Disclosure(itemLink, { _stateDispatchesOnly: true });
+        const disclosure = new Disclosure(
+          itemLink,
+          {
+            autoClose: this.autoClose,
+            _stateDispatchesOnly: true,
+          }
+        );
 
         this.disclosures.push(disclosure);
       }

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -49,11 +49,6 @@ export default class Menu extends AriaComponent {
     const {
       _stateDispatchesOnly,
     } = {
-      /**
-       * Defaults.
-       *
-       * @type {object}
-       */
       _stateDispatchesOnly: false,
 
       ...options,

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -157,8 +157,7 @@ describe('Popup correctly responds to events', () => {
     'Should move focus to the first popup child on TAB from controller',
     () => {
       controller.dispatchEvent(keydownTab);
-      expect(document.activeElement)
-        .toEqual(domFirstChild);
+      expect(document.activeElement).toEqual(domFirstChild);
     }
   );
 

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -177,7 +177,7 @@ export default class Popup extends AriaComponent {
       SPACE,
       RETURN,
     } = keyCodes;
-    const { keyCode } = event;
+    const { keyCode, shiftKey } = event;
 
     if ([SPACE, RETURN].includes(keyCode)) {
       event.preventDefault();
@@ -197,7 +197,7 @@ export default class Popup extends AriaComponent {
          * controller), there's no need to move focus.
          */
         this.hide();
-      } else if (TAB === keyCode) {
+      } else if (TAB === keyCode && ! shiftKey) {
         event.preventDefault();
 
         /*


### PR DESCRIPTION
* Corrects an issue where shift-tab from the Popup controller would focus the target's first child
* Adds an `autoClose` option to Disclosure and Menu