### PR TITLE
Options refractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Components track attributes they add and will only overwrite existing attribute values where required (#73)
 - Adds an autoClose option to Disclosure and Menu (#75, #76)
 - Adds event namespaces: `'<componentName>.<eventName>'` (#77)
+- Some options can be set after the component initializes (#82)
 
 **Fixed**
 

--- a/src/Disclosure/Disclosure.test.js
+++ b/src/Disclosure/Disclosure.test.js
@@ -79,7 +79,7 @@ describe('The Disclosure should initialize as expected', () => {
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  test('Click events on the Diusclosure controller updates atttributes as expected', () => {
+  test('Click events on the Disclosure controller updates atttributes as expected', () => {
     // Click to open.
     controller.dispatchEvent(click);
     expect(onStateChange).toHaveBeenCalledTimes(1);
@@ -172,7 +172,7 @@ describe('The Disclosure should initialize as expected', () => {
       disclosure.allowOutsideClick = false;
     });
 
-    test('The Disclosure closes when an external element it clicked', () => {
+    test('The Disclosure closes when an external element is clicked', () => {
       document.body.dispatchEvent(click);
 
       expect(disclosure.getState().expanded).toBe(false);

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -116,10 +116,10 @@ export default class Disclosure extends AriaComponent {
    *                                        when the user interacts with external content
    */
   set allowOutsideClick(shouldAllowOutsideClick) {
-    if (! shouldAllowOutsideClick) {
-      document.body.addEventListener('click', this.closeOnOutsideClick);
-    } else {
+    if (shouldAllowOutsideClick) {
       document.body.removeEventListener('click', this.closeOnOutsideClick);
+    } else {
+      document.body.addEventListener('click', this.closeOnOutsideClick);
     }
   }
 

--- a/src/Disclosure/index.js
+++ b/src/Disclosure/index.js
@@ -10,7 +10,7 @@ import interactiveChildren from '../lib/interactiveChildren';
  */
 export default class Disclosure extends AriaComponent {
   /**
-   * Initial loadOpen option value.
+   * Initial `loadOpen` option value.
    * @private
    *
    * @type {Boolean}

--- a/src/Listbox/README.md
+++ b/src/Listbox/README.md
@@ -71,6 +71,9 @@ _**`target`**_ `HTMLElement`
 _**`options`**_ `array`  
 > The target element's list items.
 
+_**`activeDescendant`**_ `HTMLElement`  
+> Set and get selected option.
+
 ### Events
 
 | Event | Description |

--- a/src/Menu/index.js
+++ b/src/Menu/index.js
@@ -8,6 +8,14 @@ import Disclosure from '../Disclosure';
  */
 export default class Menu extends AriaComponent {
   /**
+   * Initial `autoClose` option value.
+   * @private
+   *
+   * @type {Boolean}
+   */
+  #optionAutoClose = false;
+
+  /**
    * Create a Menu.
    * @constructor
    *
@@ -35,7 +43,7 @@ export default class Menu extends AriaComponent {
     const {
       autoClose,
     } = {
-      autoClose: false,
+      autoClose: this.#optionAutoClose,
 
       ...options,
     };
@@ -62,6 +70,19 @@ export default class Menu extends AriaComponent {
   }
 
   /**
+   * Enables the Disclosures' `autoClose` option.
+   *
+   * @param {bool} shouldAutoClose Whether the Disclosure should close automatically.
+   */
+  set autoClose(shouldAutoClose) {
+    if (shouldAutoClose) {
+      this.on('disclosure.stateChange', this.handleAutoClose);
+    } else {
+      this.off('disclosure.stateChange', this.handleAutoClose);
+    }
+  }
+
+  /**
    * Collect menu links and recursively instantiate sublist menu items.
    */
   init() {
@@ -81,8 +102,8 @@ export default class Menu extends AriaComponent {
         const disclosure = new Disclosure(
           itemLink,
           {
-            autoClose: this.autoClose,
-            allowOutsideClick: ! this.autoClose,
+            autoClose: this.#optionAutoClose,
+            allowOutsideClick: ! this.#optionAutoClose,
           }
         );
 

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -43,8 +43,8 @@ popup.on('popup.stateChange', onStateChange);
 // Popup has to be instanitated.
 popup.init();
 
-describe('Popup adds and manipulates DOM element attributes', () => {
-  it('Should be instantiated as expected', () => {
+describe('The Popup should initialize as expected', () => {
+  test('The Popup includes the expected property values', () => {
     expect(popup).toBeInstanceOf(Popup);
     expect(popup.toString()).toEqual('[object Popup]');
 
@@ -52,7 +52,9 @@ describe('Popup adds and manipulates DOM element attributes', () => {
 
     expect(popup.firstInteractiveChild).toEqual(domFirstChild);
     expect(popup.lastInteractiveChild).toEqual(domLastChild);
+  });
 
+  test('The `init` event fires once', () => {
     expect(popup.getState().expanded).toBeFalsy();
 
     // All interactive children should initially have a negative tabindex.
@@ -61,7 +63,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     });
   });
 
-  it('Should add the correct attributes to the popup controller', () => {
+  test('The Popup controller includes the expected attribute values', () => {
     expect(controller.getAttribute('aria-haspopup')).toEqual('true');
     expect(controller.getAttribute('aria-expanded')).toEqual('false');
 
@@ -72,11 +74,11 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     expect(controller.getAttribute('aria-own')).toBeFalsy();
   });
 
-  it('Should add the correct attributes to the popup target', () => {
+  test('The Popup target includes the expected attribute values', () => {
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  it('Should fire `stateChange` event on state change: open', () => {
+  test('Expanded state changes update properties and attributes as expected', () => {
     popup.show();
     expect(popup.getState().expanded).toBe(true);
     expect(onStateChange).toHaveBeenCalledTimes(1);
@@ -90,7 +92,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     });
   });
 
-  it('Should fire `stateChange` event on state change: hidden', () => {
+  test('Hidden state changes update properties and attributes as expected', () => {
     popup.hide();
     expect(popup.getState().expanded).toBe(false);
     expect(onStateChange).toHaveBeenCalledTimes(2);
@@ -104,7 +106,7 @@ describe('Popup adds and manipulates DOM element attributes', () => {
     });
   });
 
-  it('Should update attributes when the controller is clicked', () => {
+  test('Click events on the Popup controller updates atttributes as expected', () => {
     // Click to open.
     controller.dispatchEvent(click);
     expect(popup.getState().expanded).toBeTruthy();
@@ -129,41 +131,25 @@ describe('Popup adds and manipulates DOM element attributes', () => {
       expect(link.getAttribute('tabindex')).toEqual('-1');
     });
   });
-
-  it('Should run class methods and subscriber functions', () => {
-    popup.show();
-    expect(onStateChange).toHaveBeenCalledTimes(5);
-
-    popup.hide();
-    expect(onStateChange).toHaveBeenCalledTimes(6);
-  });
 });
 
 describe('Popup correctly responds to events', () => {
   // Ensure the popup is open before all tests.
-  beforeEach(() => {
-    popup.show();
+  beforeEach(() => popup.show());
+
+  test('The Disclosure closes when the Escape key is pressed', () => {
+    controller.focus();
+    controller.dispatchEvent(keydownEscape);
+    expect(popup.getState().expanded).toBeFalsy();
+    expect(document.activeElement).toEqual(controller);
   });
 
-  it(
-    'Should close the popup when the Escape key is pressed',
-    () => {
-      controller.focus();
-      controller.dispatchEvent(keydownEscape);
-      expect(popup.getState().expanded).toBeFalsy();
-      expect(document.activeElement).toEqual(controller);
-    }
-  );
+  test('Should move focus to the first popup child on Tab from controller', () => {
+    controller.dispatchEvent(keydownTab);
+    expect(document.activeElement).toEqual(domFirstChild);
+  });
 
-  it(
-    'Should move focus to the first popup child on Tab from controller',
-    () => {
-      controller.dispatchEvent(keydownTab);
-      expect(document.activeElement).toEqual(domFirstChild);
-    }
-  );
-
-  it('Should update Popup state with keyboard', () => {
+  test('Should update Popup state with keyboard', () => {
     // Toggle popup
     controller.dispatchEvent(keydownSpace);
     expect(popup.getState().expanded).toBeFalsy();
@@ -174,8 +160,8 @@ describe('Popup correctly responds to events', () => {
   });
 
   // eslint-disable-next-line max-len
-  it(
-    'Should close the popup and focus the controller when the Escape key is pressed',
+  test(
+    'The Disclosure closes and focus is moved to the controller when the Escape key is pressed',
     () => {
       target.dispatchEvent(keydownEscape);
       expect(popup.getState().expanded).toBeFalsy();
@@ -183,44 +169,31 @@ describe('Popup correctly responds to events', () => {
     }
   );
 
-  it(
-    'Should close the popup when tabbing from the last child',
-    () => {
-      domLastChild.focus();
-      target.dispatchEvent(keydownTab);
-      expect(popup.getState().expanded).toBeFalsy();
-    }
-  );
+  test('The Disclosure closes when Tabbing from the last child', () => {
+    domLastChild.focus();
+    target.dispatchEvent(keydownTab);
+    expect(popup.getState().expanded).toBeFalsy();
+  });
 
-  it(
-    'Should not close the popup when tabbing back from the last child',
-    () => {
-      domLastChild.focus();
-      target.dispatchEvent(keydownShiftTab);
-      expect(popup.getState().expanded).toBeTruthy();
-    }
-  );
+  test('The Disclosure remains open when tabbing back from the last child', () => {
+    domLastChild.focus();
+    target.dispatchEvent(keydownShiftTab);
+    expect(popup.getState().expanded).toBeTruthy();
+  });
 
-  it(
-    'Should focus the controller when tabbing back from the first child',
-    () => {
-      domFirstChild.focus();
-      target.dispatchEvent(keydownShiftTab);
-      expect(document.activeElement).toEqual(controller);
-    }
-  );
+  test('Focus moves to the controller when tabbing back from the first child', () => {
+    domFirstChild.focus();
+    target.dispatchEvent(keydownShiftTab);
+    expect(document.activeElement).toEqual(controller);
+  });
 
-  it(
-    'Should close the popup when an outside element it clicked',
-    () => {
-      document.body.dispatchEvent(click);
-      expect(popup.getState().expanded).toBeFalsy();
-    }
-  );
-});
+  test('The Disclosure closes when an external element is clicked', () => {
+    document.body.dispatchEvent(click);
 
-describe('Popup destroy', () => {
-  it('Should destroy the popup as expected', () => {
+    expect(popup.getState().expanded).toBeFalsy();
+  });
+
+  test('All attributes are removed from elements managed by the Disclosure', () => {
     popup.destroy();
 
     if ('BUTTON' !== controller.nodeName && null === controller.getAttribute('role')) {

--- a/src/Popup/index.js
+++ b/src/Popup/index.js
@@ -8,6 +8,14 @@ import interactiveChildren from '../lib/interactiveChildren';
  */
 export default class Popup extends AriaComponent {
   /**
+   * Initial `type` option value.
+   * @private
+   *
+   * @type {Boolean}
+   */
+  #optionType = 'true'; // 'true' === 'menu' in UAs that don't support WAI-ARIA 1.1
+
+  /**
    * Create a MenuBar.
    * @constructor
    *
@@ -37,13 +45,13 @@ export default class Popup extends AriaComponent {
        *
        * @type {string}
        */
-      type: 'true', // 'true' === 'menu' in UAs that don't support WAI-ARIA 1.1
+      type: this.#optionType,
 
       ...options,
     };
 
     // Set options.
-    this.type = type;
+    this.#optionType = type;
 
     // Intial component state.
     this.state = { expanded: false };
@@ -93,7 +101,7 @@ export default class Popup extends AriaComponent {
     }
 
     // Add controller attributes
-    this.addAttribute(this.controller, 'aria-haspopup', this.type);
+    this.addAttribute(this.controller, 'aria-haspopup', this.#optionType);
     this.addAttribute(this.controller, 'aria-expanded', 'false');
 
     // Patch button role and behavior for non-button controller.

--- a/src/Tablist/index.js
+++ b/src/Tablist/index.js
@@ -25,6 +25,11 @@ export default class Tablist extends AriaComponent {
      */
     this[Symbol.toStringTag] = 'Tablist';
 
+    /**
+     * The list element containing tab links
+     *
+     * @type {HTMLULElement|HTMLOLElement}
+     */
     this.tabs = tabs;
 
     // Merge options as instance properties.


### PR DESCRIPTION
* Moves options to setter and getter properties, where it makes sense
* Uses private fields for static option values
* Cleans up tests where possible