### PR TITLE
Dialog Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ A complete rewrite.
 ### Highlights
 
 * **Simplified component parameters**: For components with a controller-target pair, pass in either the controller or target. Just be sure to add the `aria-controls` attribute to the controlling element with a matching `id` attribute on the target element. (#51, #66, #65, #70)
-* **Extend core functionality with Modules**: Modules contain optional features and functionality available for contexts in which they'll simplify and/or improve UX (#84, #86)
+* **Extend core functionality with Modules**: Modules contain optional features and functionality available for contexts in which they'll simplify and/or improve UX (#84, #86, #95)
 * **Custom events**: Components dispatch custom `init`, `stateChange` and `destroy` events, rather than accepting callbacks (#55, #77)
 
 ... and more:
@@ -22,7 +22,6 @@ A complete rewrite.
 
 **Changed**
 
-- Dialog now focuses the target element when opened (#51)
 - Loosens the Menu component's markup requirements (#48, 3385f2e)
 - Dialog and Listbox no longer extend Popup (#59, #85)
 - Use the `Dialog.closeButton` setter to configure the Dialog close button (#86)
@@ -31,7 +30,6 @@ A complete rewrite.
 **Added**
 
 - Uses `[Symbol.toStringTag]` for component identification via `instance.toString()` (#52)
-- Gets Dialog content element(s) if none provided (#51)
 - Logs a configuration error for misconfigured components (#51)
 - Adds an `autoClose` option to Disclosure and Menu (#75, #76)
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -48,18 +48,7 @@ export default class Dialog extends AriaComponent {
      *
      * @type {object}
      */
-    const {
-      content,
-      closeButton,
-    } = {
-      /**
-       * The element(s) to be hidden when the Dialog is visible. The elements
-       * wrapping all site content with the sole exception of the dialog element.
-       *
-       * @type {HTMLElement|NodeList|Array}
-       */
-      content: [],
-
+    const { closeButton } = {
       /**
        * The element used to close the Dialog.
        *
@@ -73,9 +62,6 @@ export default class Dialog extends AriaComponent {
     // Set the close button.
     this.closeButton = closeButton;
 
-    // Save static options.
-    this.content = content;
-
     this.init();
   }
 
@@ -88,13 +74,7 @@ export default class Dialog extends AriaComponent {
     // Update state.
     this.#expanded = newState;
 
-    const contentLength = this.content.length;
-
     this.setInteractiveChildren();
-
-    for (let i = 0; i < contentLength; i += 1) {
-      this.updateAttribute(this.content[i], 'aria-hidden', (this.expanded || null));
-    }
 
     // Update target element.
     this.updateAttribute(this.target, 'aria-hidden', (! this.expanded));
@@ -149,27 +129,6 @@ export default class Dialog extends AriaComponent {
    * Set the component's DOM attributes and event listeners.
    */
   init = () => {
-    // Get the content items if none are provided.
-    if (0 === this.content.length || undefined === this.content) {
-      this.content = Array.from(document.body.children)
-        .filter((child) => ! child.contains(this.target));
-    } else {
-      this.content = Array.from(this.content);
-    }
-
-    // If no content is found.
-    if (0 === this.content.length) {
-      AriaComponent.configurationError(
-        'The Dialog target should not be within the main site content'
-      );
-    }
-
-    // Be sure each element has an id attribute for internal attribute tracking.
-    const contentLength = this.content.length;
-    for (let i = 0; i < contentLength; i += 1) {
-      this.addAttribute(this.content[i], this.constructor.getUniqueId());
-    }
-
     /*
      * Collect the Dialog's interactive child elements. This is an initial pass
      * to ensure values exists, but the interactive children will be collected
@@ -311,12 +270,6 @@ export default class Dialog extends AriaComponent {
    * Destroy the Dialog and Popup.
    */
   destroy = () => {
-    // Remove the `aria-hidden` attribute from the content wrapper.
-    const contentLength = this.content.length;
-    for (let i = 0; i < contentLength; i += 1) {
-      this.removeAttributes(this.content[i]);
-    }
-
     // Remove attributes.
     this.removeAttributes(this.controller);
     this.removeAttributes(this.target);

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -74,12 +74,12 @@ export default class Dialog extends AriaComponent {
     // Update state.
     this.#expanded = newState;
 
-    this.setInteractiveChildren();
-
     // Update target element.
     this.updateAttribute(this.target, 'aria-hidden', (! this.expanded));
 
     if (this.expanded) {
+      this.setInteractiveChildren();
+
       document.body.addEventListener('keydown', this.bodyHandleKeydown);
 
       if (null != this.#closeButton) {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -102,7 +102,9 @@ export default class Dialog extends AriaComponent {
     if (this.expanded) {
       document.body.addEventListener('keydown', this.bodyHandleKeydown);
 
-      this.target.focus();
+      if (null != this.#closeButton) {
+        this.#closeButton.focus();
+      }
     } else {
       document.body.removeEventListener('keydown', this.bodyHandleKeydown);
 
@@ -174,9 +176,6 @@ export default class Dialog extends AriaComponent {
      * each time the dialog opens, in case the dialog's contents change.
      */
     this.setInteractiveChildren();
-
-    // Allow focus on the target element.
-    this.addAttribute(this.target, 'tabindex', '0');
 
     /*
      * Set the target as hidden by default. Using the `aria-hidden` attribute,

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -3,7 +3,7 @@ import getElementPair from '../shared/getElementPair';
 import interactiveChildren from '../shared/interactiveChildren';
 
 /**
- * Class to set up an interactive Dialog element.
+ * Class to set up an interactive Modal Dialog element.
  */
 export default class Dialog extends AriaComponent {
   /**
@@ -82,6 +82,7 @@ export default class Dialog extends AriaComponent {
 
       document.body.addEventListener('keydown', this.bodyHandleKeydown);
 
+      // The close button may not be the most appropriate element to focus.
       if (null != this.#closeButton) {
         this.#closeButton.focus();
       }
@@ -136,11 +137,7 @@ export default class Dialog extends AriaComponent {
      */
     this.setInteractiveChildren();
 
-    /*
-     * Set the target as hidden by default. Using the `aria-hidden` attribute,
-     * rather than the `hidden` attribute, means authors must hide the target
-     * element via CSS.
-     */
+    // Set the target as hidden by default.
     this.addAttribute(this.target, 'aria-hidden', 'true');
 
     // Set additional attributes.
@@ -164,6 +161,7 @@ export default class Dialog extends AriaComponent {
    * @param {HTMLButtonElement} button The Dialog's close element.
    */
   set closeButton(button) {
+    // Be sure to stop listening to the old button, if necessary.
     if (null != this.#closeButton) {
       this.#closeButton.removeEventListener('click', this.hide);
     }
@@ -219,7 +217,7 @@ export default class Dialog extends AriaComponent {
   };
 
   /**
-   * Close the dialog on 'Escape' key press. This is added to the body element,
+   * Close the dialog on 'Escape' key press. This is added to the body element
    * so any press of the 'Escape' key will short-circuit the dialog and move
    * focus back to the controller.
    *

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -176,19 +176,6 @@ export default class Dialog extends AriaComponent {
   }
 
   /**
-   * Close the dialog on when users click outside of the Dialog element.
-   *
-   * @todo This isn't actually used.
-   *
-   * @param {Event} event The Event object.
-   */
-  outsideClick = (event) => {
-    if (this.expanded && ! this.target.contains(event.target)) {
-      this.hide();
-    }
-  };
-
-  /**
    * Show the Dialog when the controller is clicked.
    *
    * @param {Event} event The event object.

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -212,15 +212,12 @@ export default class Dialog extends AriaComponent {
 
       if (
         shiftKey
-        && (
-          this.firstInteractiveChild === activeElement
-          || this.target === activeElement
-        )
+        && this.firstInteractiveChild === activeElement
       ) {
         event.preventDefault();
         /*
-         * Move back from the first interactive child element, or dialog element
-         * itself, to the last interactive child element.
+         * Move back from the first interactive child element to the last
+         * interactive child element.
          */
         this.lastInteractiveChild.focus();
       } else if (! shiftKey && this.lastInteractiveChild === activeElement) {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -235,9 +235,9 @@ export default class Dialog extends AriaComponent {
   };
 
   /**
-   * Close the dialog on 'Escape' key press. This is added to the body element, so
-   * any press of the 'Escape' key will short-circuit the dialog and move forcus back
-   * to the controller.
+   * Close the dialog on 'Escape' key press. This is added to the body element,
+   * so any press of the 'Escape' key will short-circuit the dialog and move
+   * focus back to the controller.
    *
    * @param {Event} event The Event object.
    */
@@ -247,18 +247,6 @@ export default class Dialog extends AriaComponent {
     switch (key) {
       case 'Escape':
         this.hide();
-        break;
-
-      case 'Tab':
-        if (this.expanded && ! this.target.contains(eventTarget)) {
-          event.preventDefault();
-
-          /*
-           * Move focus to the first interactive child element. This is a stopgap
-           * for instances where clicking outside of the Dialog moves focus out.
-           */
-          this.firstInteractiveChild.focus();
-        }
         break;
 
       default:

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -48,7 +48,10 @@ export default class Dialog extends AriaComponent {
      *
      * @type {object}
      */
-    const { content } = {
+    const {
+      content,
+      closeButton,
+    } = {
       /**
        * The element(s) to be hidden when the Dialog is visible. The elements
        * wrapping all site content with the sole exception of the dialog element.
@@ -57,8 +60,18 @@ export default class Dialog extends AriaComponent {
        */
       content: [],
 
+      /**
+       * The element used to close the Dialog.
+       *
+       * @type {HTMLButtonElement}
+       */
+      closeButton: null,
+
       ...options,
     };
+
+    // Set the close button.
+    this.closeButton = closeButton;
 
     // Save static options.
     this.content = content;

--- a/src/Dialog/Dialog.modules.test.js
+++ b/src/Dialog/Dialog.modules.test.js
@@ -140,14 +140,17 @@ test('UseLegacyDialog: Uses aria-hidden on external content', () => {
     }
   );
 
+  expect(target.getAttribute('aria-hidden')).toBe('true');
   expect(footer.getAttribute('aria-hidden')).toBeNull();
   expect(content.getAttribute('aria-hidden')).toBeNull();
 
   dialog.expanded = true;
+  expect(target.getAttribute('aria-hidden')).toBe('false');
   expect(footer.getAttribute('aria-hidden')).toEqual('true');
   expect(content.getAttribute('aria-hidden')).toEqual('true');
 
   dialog.expanded = false;
+  expect(target.getAttribute('aria-hidden')).toBe('true');
   expect(footer.getAttribute('aria-hidden')).toBeNull();
   expect(content.getAttribute('aria-hidden')).toBeNull();
 

--- a/src/Dialog/Dialog.modules.test.js
+++ b/src/Dialog/Dialog.modules.test.js
@@ -42,21 +42,17 @@ const content = document.querySelector('main');
 const footer = document.querySelector('footer');
 
 let dialog;
-beforeEach(() => {
+
+test('ManageTabIndex: Manage target element tabindex', () => {
   dialog = new Dialog(
     controller,
     {
       modules: [
         ManageTabIndex,
-        UseButtonRole,
-        UseHiddenAttribute,
-        UseLegacyDialog,
       ],
     }
   );
-});
 
-test('ManageTabIndex: Manage target element tabindex', () => {
   dialog.interactiveChildElements.forEach((link) => {
     expect(link.getAttribute('tabindex')).toEqual('-1');
   });
@@ -80,6 +76,15 @@ test('ManageTabIndex: Manage target element tabindex', () => {
 });
 
 test('UseButtonRole: Treats non-button controller as a button', async () => {
+  dialog = new Dialog(
+    controller,
+    {
+      modules: [
+        UseButtonRole,
+      ],
+    }
+  );
+
   expect(controller.getAttribute('role')).toBe('button');
   expect(controller.getAttribute('tabindex')).not.toBe('0');
 
@@ -101,6 +106,15 @@ test('UseButtonRole: Treats non-button controller as a button', async () => {
 });
 
 test('UseHiddenAttribute: Uses hidden attribute when target not expanded', () => {
+  dialog = new Dialog(
+    controller,
+    {
+      modules: [
+        UseHiddenAttribute,
+      ],
+    }
+  );
+
   expect(dialog.expanded).toBe(false);
   expect(target.getAttribute('hidden')).toBe('');
 
@@ -117,6 +131,15 @@ test('UseHiddenAttribute: Uses hidden attribute when target not expanded', () =>
 });
 
 test('UseLegacyDialog: Uses aria-hidden on external content', () => {
+  dialog = new Dialog(
+    controller,
+    {
+      modules: [
+        UseLegacyDialog,
+      ],
+    }
+  );
+
   expect(footer.getAttribute('aria-hidden')).toBeNull();
   expect(content.getAttribute('aria-hidden')).toBeNull();
 

--- a/src/Dialog/Dialog.modules.test.js
+++ b/src/Dialog/Dialog.modules.test.js
@@ -4,6 +4,7 @@ import Dialog, {
   ManageTabIndex,
   UseButtonRole,
   UseHiddenAttribute,
+  UseLegacyDialog,
 } from '.';
 
 // Set up our document body
@@ -37,6 +38,9 @@ document.body.innerHTML = `
 const controller = document.querySelector('[aria-controls="dialog"]');
 const target = document.getElementById('dialog');
 
+const content = document.querySelector('main');
+const footer = document.querySelector('footer');
+
 let dialog;
 beforeEach(() => {
   dialog = new Dialog(
@@ -46,6 +50,7 @@ beforeEach(() => {
         ManageTabIndex,
         UseButtonRole,
         UseHiddenAttribute,
+        UseLegacyDialog,
       ],
     }
   );
@@ -109,4 +114,21 @@ test('UseHiddenAttribute: Uses hidden attribute when target not expanded', () =>
 
   dialog.destroy();
   expect(target.getAttribute('hidden')).toBeNull();
+});
+
+test('UseLegacyDialog: Uses aria-hidden on external content', () => {
+  expect(footer.getAttribute('aria-hidden')).toBeNull();
+  expect(content.getAttribute('aria-hidden')).toBeNull();
+
+  dialog.expanded = true;
+  expect(footer.getAttribute('aria-hidden')).toEqual('true');
+  expect(content.getAttribute('aria-hidden')).toEqual('true');
+
+  dialog.expanded = false;
+  expect(footer.getAttribute('aria-hidden')).toBeNull();
+  expect(content.getAttribute('aria-hidden')).toBeNull();
+
+  dialog.destroy();
+  expect(footer.getAttribute('aria-hidden')).toBeNull();
+  expect(content.getAttribute('aria-hidden')).toBeNull();
 });

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -142,13 +142,6 @@ describe('The Dialog correctly responds to events', () => {
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  // What was this in response to?
-  test('Focus moves back to the Dialog from outside', async () => {
-    outsideLink.focus();
-    await user.keyboard('{Tab}');
-    expect(document.activeElement).toEqual(firstItem);
-  });
-
   test('The Dialog closes when the Escape key is pressed', async () => {
     lastItem.focus();
     await user.keyboard('{Escape}');

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -17,7 +17,7 @@ const dialogMarkup = `
     </article>
   </main>
   <footer class="site-footer">Site footer</footer>
-  <div class="wrapper" id="dialog" tabindex="0">
+  <div class="wrapper" id="dialog">
     <button>Close</button>
     <ul>
       <li><a href="example.com"></a></li>
@@ -72,8 +72,6 @@ describe('The Dialog should initialize as expected', () => {
   });
 
   test('The Dialog controller includes the expected attribute values', () => {
-    expect(target.getAttribute('tabindex')).toEqual('0');
-
     expect(target.getAttribute('aria-hidden')).toEqual('true');
 
     expect(target.getAttribute('role')).toEqual('dialog');
@@ -85,7 +83,7 @@ describe('The Dialog should initialize as expected', () => {
 
     expect(modal.expanded).toBe(true);
     expect(modal.expanded).toBe(true);
-    expect(document.activeElement).toEqual(target);
+    expect(document.activeElement).toEqual(firstItem);
 
     expect(footer.getAttribute('aria-hidden')).toEqual('true');
     expect(content.getAttribute('aria-hidden')).toEqual('true');

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -50,7 +50,7 @@ const onDestroy = jest.fn();
 // The `init` event is not trackable via on/off.
 target.addEventListener('dialog.init', onInit);
 
-const modal = new Dialog(target);
+const modal = new Dialog(target, { closeButton: firstItem });
 modal.on('dialog.stateChange', onStateChange);
 modal.on('dialog.destroy', onDestroy);
 
@@ -130,8 +130,7 @@ describe('The Dialog correctly responds to events', () => {
     expect(document.activeElement).toEqual(firstItem);
   });
 
-  test('The `close` setter connects the close button', async () => {
-    modal.closeButton = firstItem;
+  test('The `closeButton` optioon connects the close button', async () => {
     await user.click(firstItem);
 
     expect(modal.expanded).toBe(false);
@@ -140,7 +139,7 @@ describe('The Dialog correctly responds to events', () => {
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  test('The `close` setter overwrites as expected', async () => {
+  test('The `closeButton` setter overwrites as expected', async () => {
     modal.closeButton = listButton;
 
     // Listener removed from old button.

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -122,7 +122,7 @@ describe('The Dialog correctly responds to events', () => {
     expect(document.activeElement).toEqual(firstItem);
   });
 
-  test('The `closeButton` optioon connects the close button', async () => {
+  test('The `closeButton` option connects the close button', async () => {
     await user.click(firstItem);
 
     expect(modal.expanded).toBe(false);

--- a/src/Dialog/Dialog.test.js
+++ b/src/Dialog/Dialog.test.js
@@ -13,7 +13,7 @@ const dialogMarkup = `
       voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
       sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
       mollit anim id est laborum.</p>
-      <a aria-controls="dialog" class="link" href="#dialog">Open dialog</a>
+      <button aria-controls="dialog" class="link">Open dialog</button>
     </article>
   </main>
   <footer class="site-footer">Site footer</footer>
@@ -33,8 +33,6 @@ document.body.innerHTML = dialogMarkup;
 
 const controller = document.querySelector('[aria-controls="dialog"]');
 const target = document.getElementById('dialog');
-const content = document.querySelector('main');
-const footer = document.querySelector('footer');
 const outsideLink = document.querySelector('.outside-link');
 
 // Cached elements.
@@ -85,8 +83,6 @@ describe('The Dialog should initialize as expected', () => {
     expect(modal.expanded).toBe(true);
     expect(document.activeElement).toEqual(firstItem);
 
-    expect(footer.getAttribute('aria-hidden')).toEqual('true');
-    expect(content.getAttribute('aria-hidden')).toEqual('true');
     expect(target.getAttribute('aria-hidden')).toEqual('false');
   });
 
@@ -107,8 +103,6 @@ describe('The Dialog should initialize as expected', () => {
     expect(document.activeElement).toEqual(controller);
     expect(onStateChange).toHaveBeenCalledTimes(2);
 
-    expect(footer.getAttribute('aria-hidden')).toBeNull();
-    expect(content.getAttribute('aria-hidden')).toBeNull();
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 });
@@ -132,8 +126,6 @@ describe('The Dialog correctly responds to events', () => {
     await user.click(firstItem);
 
     expect(modal.expanded).toBe(false);
-    expect(footer.getAttribute('aria-hidden')).toBeNull();
-    expect(content.getAttribute('aria-hidden')).toBeNull();
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 
@@ -147,8 +139,6 @@ describe('The Dialog correctly responds to events', () => {
     await user.click(listButton);
 
     expect(modal.expanded).toBe(false);
-    expect(footer.getAttribute('aria-hidden')).toBeNull();
-    expect(content.getAttribute('aria-hidden')).toBeNull();
     expect(target.getAttribute('aria-hidden')).toEqual('true');
   });
 

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -3,6 +3,17 @@ Dialog
 
 Class for managing an interactive Dialog element.
 
+## Contents
+
+* [Example](#example)
+* [Constructor](#constructor)
+  * [Available Options](#available-options)
+* [Instance Methods](#instance-methods)
+* [Properties](#properties)
+* [Events](#events)
+* [Modules](#modules)
+* [References](#references)
+
 ## Example
 
 ```html

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -172,6 +172,10 @@ dialog.on('dialog.stateChange', (event) => {
 });
 ```
 
+**DOM Mutations**
+
+We can use `dialog.setInteractiveChildren()` to refresh the component after markup changes.
+
 ## References
 
 - https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -13,6 +13,7 @@ Class for managing an interactive Dialog element.
 * [Events](#events)
 * [Modules](#modules)
 * [References](#references)
+* [Additional Information](#additional-information)
 
 ## Example
 
@@ -148,6 +149,9 @@ Uses `aria-hidden` to hide outside content rather than using the `aria-model` at
 
 The `UseLegacyDialog` module adds support for a **`content`** option, which defines the `HTMLElement` or `NodeList` of elements that should be inaccessible when the Dialog element is open. _Default is `[]`_
 
+## Additional Information
+
+Authors are responsible for adding the `aria-labelledby` and `aria-describedby` attributes. See ["Role, Property, State, and Tabindex Attributes"](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/#rps_label) for more.
 
 ## References
 

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -142,6 +142,13 @@ Mimics a button for non-button controllers by using `role=button` and mapping th
 
 Hides the target element with the `hidden` attribute, removing the need to do it with CSS. Note that the use of the hidden attribute can hinder animations.
 
+**`UseLegacyDialog`**
+
+Uses `aria-hidden` to hide outside content rather than using the `aria-model` attribute. See the section titled "Notes on aria-modal and aria-hidden" on [the Modal Dialog Example page](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/).
+
+The `UseLegacyDialog` module adds support for a **`content`** option, which defines the `HTMLElement` or `NodeList` of elements that should be inaccessible when the Dialog element is open. _Default is `[]`_
+
+
 ## References
 
 - https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -153,6 +153,25 @@ The `UseLegacyDialog` module adds support for a **`content`** option, which defi
 
 Authors are responsible for adding the `aria-labelledby` and `aria-describedby` attributes. See ["WAI-ARIA Roles, States, and Properties"](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#wai-ariaroles,states,andproperties) for more.
 
+Additionally, the close button may not be the most appropriate element to focus when the Dialog opens:
+
+> When a dialog opens, focus moves to an element contained in the dialog. Generally, focus is initially set on the first focusable element. However, the most appropriate focus placement will depend on the nature and size of the content.
+
+If the close button is not the most appropriate element to focus when the Dialog opens, we can omit the `closeButton` option to prevent the Dialog from managing focus. We can then manage focus and the close button ourselves.
+
+```jsx
+// Set up the close button.
+const cancelButton = dialog.target.querySelector('button.cancel');
+cancelButton.addEventListener('click', dialog.hide);
+
+dialog.on('dialog.stateChange', (event) => {
+  const { detail } = event;
+  if (detail.expanded) {
+    // Manage focus.
+  }
+});
+```
+
 ## References
 
 - https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -151,7 +151,7 @@ The `UseLegacyDialog` module adds support for a **`content`** option, which defi
 
 ## Additional Information
 
-Authors are responsible for adding the `aria-labelledby` and `aria-describedby` attributes. See ["Role, Property, State, and Tabindex Attributes"](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/#rps_label) for more.
+Authors are responsible for adding the `aria-labelledby` and `aria-describedby` attributes. See ["WAI-ARIA Roles, States, and Properties"](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#wai-ariaroles,states,andproperties) for more.
 
 ## References
 

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -60,6 +60,8 @@ The activating element is required to have an `aria-controls` attribute with a v
 
 **`content`** - The `HTMLElement` or `NodeList` of elements that should be inaccessible when the Dialog element is open. _Default is `null`_
 
+**`closeButton`** - Designate a button element as the Dialog close button.
+
 **`modules`** - A single module, or array of modules, to initialize. _Default is `[]`_
 
 ## Instance Methods

--- a/src/Dialog/README.md
+++ b/src/Dialog/README.md
@@ -58,8 +58,6 @@ The activating element is required to have an `aria-controls` attribute with a v
 
 ### Available Options
 
-**`content`** - The `HTMLElement` or `NodeList` of elements that should be inaccessible when the Dialog element is open. _Default is `null`_
-
 **`closeButton`** - Designate a button element as the Dialog close button.
 
 **`modules`** - A single module, or array of modules, to initialize. _Default is `[]`_

--- a/src/Dialog/modules/index.js
+++ b/src/Dialog/modules/index.js
@@ -4,8 +4,12 @@ import {
   UseHiddenAttribute,
 } from '../../shared/modules';
 
+// Local modules.
+import UseLegacyDialog from './useLegacyDialog';
+
 export {
   ManageTabIndex,
   UseButtonRole,
   UseHiddenAttribute,
+  UseLegacyDialog,
 };

--- a/src/Dialog/modules/useLegacyDialog.js
+++ b/src/Dialog/modules/useLegacyDialog.js
@@ -1,0 +1,58 @@
+/**
+ * Dialog module to use `aria-hidden` to hide outside content rather than using
+ * the `aria-model` attribute.
+ *
+ * @param  {Dialog} arg.component The Dialog component instance.
+ * @param  {object} arg.options   The options passed to the component instance.
+ * @return {Function} The cleanup function.
+ */
+export default function UseLegacyDialog({ component, options }) {
+  let { content } = {
+    /**
+     * The element(s) to be hidden when the Dialog is visible. The elements
+     * wrapping all site content with the sole exception of the dialog element.
+     *
+     * @type {HTMLElement|NodeList}
+     */
+    content: [],
+
+    ...options,
+  };
+
+  // Get the content items if none are provided.
+  if (null == content || 0 === content.length) {
+    content = Array.from(document.body.children)
+      .filter((child) => ! child.contains(component.target));
+  } else {
+    content = Array.from(content);
+  }
+
+  const contentLength = content.length;
+
+  /**
+   * Hide and unhide external content when the Dialog changes state.
+   */
+  const handleStateChange = () => {
+    for (let i = 0; i < contentLength; i += 1) {
+      component.updateAttribute(content[i], 'aria-hidden', (component.expanded || null));
+    }
+  };
+
+  if (0 < contentLength) {
+    // Remove the `aria-modal` attribute.
+    component.addAttribute(component.target, 'aria-modal', null);
+
+    component.on('dialog.stateChange', handleStateChange);
+
+    // Set initial attributes.
+    for (let i = 0; i < contentLength; i += 1) {
+      component.addAttribute(content[i], component.constructor.getUniqueId());
+    }
+  }
+
+  return () => {
+    for (let i = 0; i < contentLength; i += 1) {
+      component.removeAttributes(content[i]);
+    }
+  };
+}

--- a/src/Dialog/modules/useLegacyDialog.js
+++ b/src/Dialog/modules/useLegacyDialog.js
@@ -9,8 +9,8 @@
 export default function UseLegacyDialog({ component, options }) {
   let { content } = {
     /**
-     * The element(s) to be hidden when the Dialog is visible. The elements
-     * wrapping all site content with the sole exception of the dialog element.
+     * The element or elements containing a portion of the inert layer. When the
+     * Dialog opens, `aria-hidden` is set to true on each element
      *
      * @type {HTMLElement|NodeList}
      */
@@ -30,7 +30,7 @@ export default function UseLegacyDialog({ component, options }) {
   const contentLength = content.length;
 
   /**
-   * Hide and unhide external content when the Dialog changes state.
+   * Hide and unhide the inert layer when the Dialog changes state.
    */
   const handleStateChange = () => {
     for (let i = 0; i < contentLength; i += 1) {
@@ -41,7 +41,7 @@ export default function UseLegacyDialog({ component, options }) {
   if (0 < contentLength) {
     // Remove the `aria-modal` attribute.
     component.addAttribute(component.target, 'aria-modal', null);
-
+    // Manage the inert layer.
     component.on('dialog.stateChange', handleStateChange);
 
     // Set initial attributes.
@@ -50,6 +50,7 @@ export default function UseLegacyDialog({ component, options }) {
     }
   }
 
+  // Clean up.
   return () => {
     for (let i = 0; i < contentLength; i += 1) {
       component.removeAttributes(content[i]);


### PR DESCRIPTION
* Validates the Dialog component against W3 WAI Authoring Practices Guide
* Moves "legacy dialog implementation" to a module (`UseLegacyDialog`)
* Adds an option for passing in a `closeButton`
* Never focus the Dialog element itself
* Documentation cleanup